### PR TITLE
Fixing build on windows with Visual Studio

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -5,7 +5,9 @@
 #include "leveldb/c.h"
 
 #include <stdlib.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include "leveldb/cache.h"
 #include "leveldb/comparator.h"
 #include "leveldb/db.h"


### PR DESCRIPTION
Building project with Microsoft tools choke on this include file:<unistd.h> 
It should be excluded when compiled with Visual Studio compiler on MS OS.
