### PR TITLE
log compaction output file's level along with number

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -823,7 +823,7 @@ Status DBImpl::FinishCompactionOutputFile(CompactionState* compact,
       Log(options_.info_log,
           "Generated table #%llu@%d: %lld keys, %lld bytes",
           (unsigned long long) output_number,
-		  compact->compaction->level(),
+          compact->compaction->level(),
           (unsigned long long) current_entries,
           (unsigned long long) current_bytes);
     }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -821,8 +821,9 @@ Status DBImpl::FinishCompactionOutputFile(CompactionState* compact,
     delete iter;
     if (s.ok()) {
       Log(options_.info_log,
-          "Generated table #%llu: %lld keys, %lld bytes",
+          "Generated table #%llu@%d: %lld keys, %lld bytes",
           (unsigned long long) output_number,
+		  compact->compaction->level(),
           (unsigned long long) current_entries,
           (unsigned long long) current_bytes);
     }


### PR DESCRIPTION
The `FinishCompactionOutputFile()` method write a log like this:

```
Generated table #132: 803288 keys, 21119441 bytes
```
The level of the output file is missing, I change it to write log message like this:

```
Generated table #132@1: 803288 keys, 21119441 bytes
```

Which is similar to other logs, like

```
Compacted 1@1 + 1@2 files => 17115883 bytes
```


