### PR TITLE
remove unnecessary key compare in DBIter::Next

### DIFF
--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -167,7 +167,13 @@ void DBIter::Next() {
     SaveKey(ExtractUserKey(iter_->key()), &saved_key_);
   }
 
-  FindNextUserEntry(true, &saved_key_);
+  iter_->Next();
+  if (!iter_->Valid()) {
+    valid_ = false;
+    saved_key_.clear();
+  } else {
+    FindNextUserEntry(true, &saved_key_);
+  }
 }
 
 void DBIter::FindNextUserEntry(bool skipping, std::string* skip) {


### PR DESCRIPTION
Entry can be skipped in DBIter::Next avoid comparing with itself.

The performance before:

```
LevelDB:    version 1.18
Date:       Tue Jun  2 14:24:54 2015
CPU:        8 * Intel(R) Xeon(R) CPU E5-2603 v2 @ 1.80GHz
CPUCache:   10240 KB
Keys:       16 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
RawSize:    110.6 MB (estimated)
FileSize:   62.9 MB (estimated)
WARNING: Snappy compression is not enabled
------------------------------------------------
fillseq      :       5.621 micros/op;   19.7 MB/s     
fillsync     :     217.868 micros/op;    0.5 MB/s (1000 ops)
fillrandom   :       6.861 micros/op;   16.1 MB/s     
overwrite    :       7.102 micros/op;   15.6 MB/s     
readrandom   :       6.962 micros/op; (1000000 of 1000000 found)
readrandom   :       6.096 micros/op; (1000000 of 1000000 found)
readseq      :       0.355 micros/op;  311.5 MB/s    
readreverse  :       0.760 micros/op;  145.5 MB/s    
compact      :  872202.000 micros/op;
readrandom   :       4.417 micros/op; (1000000 of 1000000 found)
readseq      :       0.302 micros/op;  366.6 MB/s    
readreverse  :       0.678 micros/op;  163.1 MB/s    
fill100K     :     866.036 micros/op;  110.1 MB/s (1000 ops)
crc32c       :       6.961 micros/op;  561.2 MB/s (4K per op)
snappycomp   :    6480.000 micros/op; (snappy failure)
snappyuncomp :    6065.000 micros/op; (snappy failure)
acquireload  :       0.613 micros/op; (each op is 1000 loads)
```

The performance after:

```
LevelDB:    version 1.18
Date:       Tue Jun  2 17:09:38 2015
CPU:        8 * Intel(R) Xeon(R) CPU E5-2603 v2 @ 1.80GHz
CPUCache:   10240 KB
Keys:       16 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
RawSize:    110.6 MB (estimated)
FileSize:   62.9 MB (estimated)
WARNING: Snappy compression is not enabled
------------------------------------------------
fillseq      :       5.572 micros/op;   19.9 MB/s     
fillsync     :     294.175 micros/op;    0.4 MB/s (1000 ops)
fillrandom   :       6.874 micros/op;   16.1 MB/s     
overwrite    :       7.038 micros/op;   15.7 MB/s     
readrandom   :       6.820 micros/op; (1000000 of 1000000 found)
readrandom   :       6.243 micros/op; (1000000 of 1000000 found)
readseq      :       0.324 micros/op;  341.2 MB/s    
readreverse  :       0.757 micros/op;  146.2 MB/s    
compact      :  846075.000 micros/op;
readrandom   :       4.403 micros/op; (1000000 of 1000000 found)
readseq      :       0.272 micros/op;  407.3 MB/s    
readreverse  :       0.655 micros/op;  168.9 MB/s    
fill100K     :     870.305 micros/op;  109.6 MB/s (1000 ops)
crc32c       :       6.958 micros/op;  561.4 MB/s (4K per op)
snappycomp   :    6482.000 micros/op; (snappy failure)
snappyuncomp :    6364.000 micros/op; (snappy failure)
acquireload  :       0.613 micros/op; (each op is 1000 loads)
```

It will has a noticeable effect on readseq.
