### PR TITLE
Add API to clear table_cache

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -550,6 +550,12 @@ void DBImpl::CompactRange(const Slice* begin, const Slice* end) {
   }
 }
 
+void DBImpl::ClearCache() {
+  MutexLock l(&mutex_);
+  table_cache_->ClearCache();
+  options_.block_cache->ClearCache();
+}
+
 void DBImpl::TEST_CompactRange(int level, const Slice* begin,const Slice* end) {
   assert(level >= 0);
   assert(level + 1 < config::kNumLevels);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -41,6 +41,7 @@ class DBImpl : public DB {
   virtual bool GetProperty(const Slice& property, std::string* value);
   virtual void GetApproximateSizes(const Range* range, int n, uint64_t* sizes);
   virtual void CompactRange(const Slice* begin, const Slice* end);
+  virtual void ClearCache();
 
   // Extra methods (for testing) that are not in the public DB interface
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1894,6 +1894,8 @@ class ModelDB: public DB {
   }
   virtual void CompactRange(const Slice* start, const Slice* end) {
   }
+  virtual void ClearCache() {
+  }
 
  private:
   class ModelIter: public Iterator {

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -124,4 +124,8 @@ void TableCache::Evict(uint64_t file_number) {
   cache_->Erase(Slice(buf, sizeof(buf)));
 }
 
+void TableCache::ClearCache() {
+  cache_->ClearCache();
+}
+
 }  // namespace leveldb

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -47,6 +47,9 @@ class TableCache {
   // Evict any entry for the specified file number
   void Evict(uint64_t file_number);
 
+  // Clears all unreferenced cache entries.
+  void ClearCache();
+
  private:
   Env* const env_;
   const std::string dbname_;

--- a/include/leveldb/cache.h
+++ b/include/leveldb/cache.h
@@ -81,6 +81,9 @@ class Cache {
   // its cache keys.
   virtual uint64_t NewId() = 0;
 
+  // Clear all cache entries that has no reference.
+  virtual void ClearCache() = 0;
+
  private:
   void LRU_Remove(Handle* e);
   void LRU_Append(Handle* e);

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -140,6 +140,9 @@ class DB {
   //    db->CompactRange(NULL, NULL);
   virtual void CompactRange(const Slice* begin, const Slice* end) = 0;
 
+  // Clear all cache that safely evictable.
+  virtual void ClearCache() = 0;
+
  private:
   // No copying allowed
   DB(const DB&);

--- a/util/cache.cc
+++ b/util/cache.cc
@@ -147,6 +147,7 @@ class LRUCache {
   Cache::Handle* Lookup(const Slice& key, uint32_t hash);
   void Release(Cache::Handle* handle);
   void Erase(const Slice& key, uint32_t hash);
+  void ClearCache();
 
  private:
   void LRU_Remove(LRUHandle* e);
@@ -264,6 +265,19 @@ void LRUCache::Erase(const Slice& key, uint32_t hash) {
   }
 }
 
+void LRUCache::ClearCache() {
+  MutexLock l(&mutex_);
+  for (LRUHandle* e = lru_.next; e != &lru_; ) {
+    LRUHandle* next = e->next;
+    if (e->refs == 1) {
+      table_.Remove(e->key(), e->hash);
+      LRU_Remove(e);
+      Unref(e);
+    }
+    e = next;
+  }
+}
+
 static const int kNumShardBits = 4;
 static const int kNumShards = 1 << kNumShardBits;
 
@@ -313,6 +327,11 @@ class ShardedLRUCache : public Cache {
   virtual uint64_t NewId() {
     MutexLock l(&id_mutex_);
     return ++(last_id_);
+  }
+  virtual void ClearCache() {
+    for (int s = 0; s < kNumShards; s++) {
+      shard_[s].ClearCache();
+    }
   }
 };
 

--- a/util/cache_test.cc
+++ b/util/cache_test.cc
@@ -179,6 +179,19 @@ TEST(CacheTest, NewId) {
   ASSERT_NE(a, b);
 }
 
+TEST(CacheTest, ClearCache) {
+  Insert(1, 100);
+  Insert(2, 200);
+
+  Cache::Handle* handle = cache_->Lookup(EncodeKey(1));
+  ASSERT_TRUE(handle);
+  cache_->ClearCache();
+  cache_->Release(handle);
+
+  ASSERT_EQ(100, Lookup(1));
+  ASSERT_EQ(-1, Lookup(2));
+}
+
 }  // namespace leveldb
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
PTAL.
Chrome holds multiple instances of LevelDB on its browser process. And they consume around 500kB for the read cache after 5 min browsing on a empty profile.
To drop them on a memory pressure, we'd like to add an API to leveldb::Cache.