### PR TITLE
Implement support for limited record lifetime

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2090,7 +2090,7 @@ void BM_LogAndApply(int iters, int num_base_files) {
   for (int i = 0; i < num_base_files; i++) {
     InternalKey start(MakeKey(2*fnum), 1, kTypeValue);
     InternalKey limit(MakeKey(2*fnum+1), 1, kTypeDeletion);
-    vbase.AddFile(2, fnum++, 1 /* file size */, start, limit);
+    vbase.AddFile(2, fnum++, 1 /* file size */, start, limit, 1);
   }
   ASSERT_OK(vset.LogAndApply(&vbase, &mu));
 
@@ -2101,7 +2101,7 @@ void BM_LogAndApply(int iters, int num_base_files) {
     vedit.DeleteFile(2, fnum);
     InternalKey start(MakeKey(2*fnum), 1, kTypeValue);
     InternalKey limit(MakeKey(2*fnum+1), 1, kTypeDeletion);
-    vedit.AddFile(2, fnum++, 1 /* file size */, start, limit);
+    vedit.AddFile(2, fnum++, 1 /* file size */, start, limit, 1);
     vset.LogAndApply(&vedit, &mu);
   }
   uint64_t stop_micros = env->NowMicros();

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -21,7 +21,8 @@ static Slice GetLengthPrefixedSlice(const char* data) {
 MemTable::MemTable(const InternalKeyComparator& cmp)
     : comparator_(cmp),
       refs_(0),
-      table_(comparator_, &arena_) {
+      table_(comparator_, &arena_),
+      last_sequence_(0) {
 }
 
 MemTable::~MemTable() {
@@ -103,6 +104,8 @@ void MemTable::Add(SequenceNumber s, ValueType type,
   memcpy(p, value.data(), val_size);
   assert((p + val_size) - buf == encoded_len);
   table_.Insert(buf);
+  // store last sequence number to stamp table
+  last_sequence_ = s;
 }
 
 bool MemTable::Get(const LookupKey& key, std::string* value, Status* s) {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -63,6 +63,11 @@ class MemTable {
   // Else, return false.
   bool Get(const LookupKey& key, std::string* value, Status* s);
 
+  // Returns last sequence number for table
+  inline SequenceNumber GetSequence() const {
+    return last_sequence_;
+  }
+
  private:
   ~MemTable();  // Private since only Unref() should be used to delete it
 
@@ -80,6 +85,7 @@ class MemTable {
   int refs_;
   Arena arena_;
   Table table_;
+  SequenceNumber last_sequence_;
 
   // No copying allowed
   MemTable(const MemTable&);

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -396,7 +396,7 @@ class Repairer {
       // TODO(opt): separate out into multiple levels
       const TableInfo& t = tables_[i];
       edit_.AddFile(0, t.meta.number, t.meta.file_size,
-                    t.meta.smallest, t.meta.largest);
+                    t.meta.smallest, t.meta.largest, t.meta.last_sequence);
     }
 
     //fprintf(stderr, "NewDescriptor:\n%s\n", edit_.DebugString().c_str());

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -21,8 +21,9 @@ struct FileMetaData {
   uint64_t file_size;         // File size in bytes
   InternalKey smallest;       // Smallest internal key served by table
   InternalKey largest;        // Largest internal key served by table
+  SequenceNumber last_sequence; // Last sequence number for keys served by table
 
-  FileMetaData() : refs(0), allowed_seeks(1 << 30), file_size(0) { }
+  FileMetaData() : refs(0), allowed_seeks(1 << 30), file_size(0), last_sequence(0) { }
 };
 
 class VersionEdit {
@@ -62,12 +63,14 @@ class VersionEdit {
   void AddFile(int level, uint64_t file,
                uint64_t file_size,
                const InternalKey& smallest,
-               const InternalKey& largest) {
+               const InternalKey& largest,
+               SequenceNumber last_sequence) {
     FileMetaData f;
     f.number = file;
     f.file_size = file_size;
     f.smallest = smallest;
     f.largest = largest;
+    f.last_sequence = last_sequence;
     new_files_.push_back(std::make_pair(level, f));
   }
 
@@ -76,7 +79,7 @@ class VersionEdit {
     deleted_files_.insert(std::make_pair(level, file));
   }
 
-  void EncodeTo(std::string* dst) const;
+  void EncodeTo(std::string* dst, bool allowNewMetadata = false) const;
   Status DecodeFrom(const Slice& src);
 
   std::string DebugString() const;

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -27,7 +27,8 @@ TEST(VersionEditTest, EncodeDecode) {
     TestEncodeDecode(edit);
     edit.AddFile(3, kBig + 300 + i, kBig + 400 + i,
                  InternalKey("foo", kBig + 500 + i, kTypeValue),
-                 InternalKey("zoo", kBig + 600 + i, kTypeDeletion));
+                 InternalKey("zoo", kBig + 600 + i, kTypeDeletion),
+                 kBig + 600 + i);
     edit.DeleteFile(4, kBig + 700 + i);
     edit.SetCompactPointer(i, InternalKey("x", kBig + 900 + i, kTypeValue));
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -257,6 +257,9 @@ class VersionSet {
   // May also mutate some internal state.
   void AddLiveFiles(std::set<uint64_t>* live);
 
+  // Registers all expired files for deletion.
+  void CollectExpiredFiles(VersionEdit* edit);
+
   // Return the approximate offset in the database of the data for
   // "key" as of version "v".
   uint64_t ApproximateOffsetOf(Version* v, const InternalKey& key);

--- a/include/leveldb/sequence_policy.h
+++ b/include/leveldb/sequence_policy.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2012 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// A database can be configured with a custom SequencePolicy object.
+// This object is responsible for generating monotonic sequences
+// for stamping writes persisted in database and controlling its lifetime.
+//
+#ifndef STORAGE_LEVELDB_INCLUDE_SEQUENCE_POLICY_H_
+#define STORAGE_LEVELDB_INCLUDE_SEQUENCE_POLICY_H_
+
+#include <ctime>
+#include <stdint.h>
+
+namespace leveldb {
+
+typedef uint64_t SequenceNumber;    // from dbformat.h
+
+class Env;
+
+class SequencePolicy {
+ public:
+  virtual ~SequencePolicy() {}
+
+  virtual SequenceNumber Next(
+    const SequenceNumber& sequence,
+    size_t count) const = 0;
+
+  virtual bool IsExpired(const SequenceNumber& sequence) const = 0;
+};
+
+inline SequenceNumber NextSequence(
+  const SequencePolicy* user_policy,
+  const SequenceNumber& sequence,
+  size_t count)
+{
+  return user_policy ? user_policy->Next(sequence, count) : sequence + count;
+}
+
+inline bool IsSequenceExpired(
+    const SequencePolicy* user_policy,
+    const SequenceNumber& sequence)
+{
+  return user_policy ? user_policy->IsExpired(sequence) : false;
+}
+
+// Returns a new sequence policy that uses system timer to track records lifetime.
+extern const SequencePolicy* NewTimeSequencePolicy(Env* env, time_t max_lifetime);
+
+}
+
+#endif  // STORAGE_LEVELDB_INCLUDE_SEQUENCE_POLICY_H_

--- a/util/options.cc
+++ b/util/options.cc
@@ -22,7 +22,8 @@ Options::Options()
       block_size(4096),
       block_restart_interval(16),
       compression(kSnappyCompression),
-      filter_policy(NULL) {
+      filter_policy(NULL),
+      sequence_policy(NULL) {
 }
 
 

--- a/util/sequence.cc
+++ b/util/sequence.cc
@@ -1,0 +1,43 @@
+// Copyright (c) 2012 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "leveldb/sequence_policy.h"
+
+#include "leveldb/env.h"
+
+namespace leveldb {
+namespace {
+
+class TimeSequencePolicy : public SequencePolicy {
+ private:
+  Env* const env_;
+  time_t max_lifetime_;
+
+ public:
+  TimeSequencePolicy(Env* env, time_t max_lifetime)
+    : env_(env), max_lifetime_(max_lifetime) {}
+
+  virtual SequenceNumber Next(
+      const SequenceNumber& sequence,
+      size_t count) const {
+    uint64_t now = env_->NowMicros();
+    return (now > sequence ? now : sequence) + count;
+  }
+
+  virtual bool IsExpired(const SequenceNumber& sequence) const {
+    if (!sequence || !max_lifetime_) {
+      return false;
+    }
+    uint64_t now = env_->NowMicros();
+    return now > sequence && max_lifetime_ < static_cast<time_t>(now - sequence);
+  }
+};
+
+}
+
+const SequencePolicy* NewTimeSequencePolicy(Env* env, time_t max_lifetime) {
+  return new TimeSequencePolicy(env, max_lifetime);
+}
+
+}  // namespace leveldb


### PR DESCRIPTION
Proposed changes allows user to specify policy to drop expired entries on compaction.
Last seqno also stored in files meta data to allow expired files to be dropped without expensive compaction process.
Keeping seqno in files' meta data also allows us to completely skip old sstables on read. 
