### PR TITLE
[PosixEnv::FileLock] fix

### DIFF
--- a/util/env_boost.cc
+++ b/util/env_boost.cc
@@ -402,8 +402,10 @@ class PosixEnv : public Env {
       boost::interprocess::file_lock fl(fname.c_str());
       BoostFileLock * my_lock = new BoostFileLock();
       my_lock->fl_ = std::move(fl);
-      my_lock->fl_.lock();
-      *lock = my_lock;
+      if (my_lock->fl_.try_lock())
+        *lock = my_lock;
+      else
+        result = Status::IOError("acquiring lock " + fname + " failed");
     } catch (const std::exception & e) {
       result = Status::IOError("lock " + fname, e.what());
     }


### PR DESCRIPTION
boost::interprocess::file_lock: lock -> try_lock, it corresponds to method Env::FileLock specification.