### PR TITLE
Implement support for meta blocks

### DIFF
--- a/db/version_set.h
+++ b/db/version_set.h
@@ -30,6 +30,7 @@ namespace log { class Writer; }
 class Compaction;
 class Iterator;
 class MemTable;
+class MetaBlockVisitor;
 class TableBuilder;
 class TableCache;
 class Version;
@@ -88,6 +89,12 @@ class Version {
   // under live iterators)
   void Ref();
   void Unref();
+
+  Status VisitMeta(
+      const Slice& meta,
+      const InternalKey* begin,         // NULL means before all keys
+      const InternalKey* end,           // NULL means after all keys
+      MetaBlockVisitor* visitor);
 
   void GetOverlappingInputs(
       int level,

--- a/include/leveldb/meta.h
+++ b/include/leveldb/meta.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2012 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// A filter block is stored near the end of a Table file.  It contains
+// filters (e.g., bloom filters) for all data blocks in the table combined
+// into a single filter block.
+
+#ifndef STORAGE_LEVELDB_TABLE_META_H_
+#define STORAGE_LEVELDB_TABLE_META_H_
+
+#include "leveldb/slice.h"
+#include "leveldb/status.h"
+
+namespace leveldb {
+
+class MetaBlock {
+ public:
+    virtual ~MetaBlock() {}
+
+    virtual Slice data() const = 0;
+};
+
+class MetaBlockBuilder {
+ public:
+  virtual ~MetaBlockBuilder() {}
+
+  virtual const char* Name() const = 0;
+
+  virtual void Add(const Slice& key, const Slice& value) = 0;
+  virtual Slice Finish() = 0;
+};
+
+class MetaBlockVisitor {
+ public:
+  virtual ~MetaBlockVisitor() {}
+
+  virtual bool PreVisit(int level, uint64_t file_number) = 0;
+  virtual Status Visit(int level, uint64_t file_number, const Slice& data) = 0;
+};
+
+}
+
+#endif  // STORAGE_LEVELDB_TABLE_META_H_

--- a/include/leveldb/table.h
+++ b/include/leveldb/table.h
@@ -13,6 +13,7 @@ namespace leveldb {
 class Block;
 class BlockHandle;
 class Footer;
+class MetaBlock;
 struct Options;
 class RandomAccessFile;
 struct ReadOptions;
@@ -46,6 +47,12 @@ class Table {
   // The result of NewIterator() is initially invalid (caller must
   // call one of the Seek methods on the iterator before using it).
   Iterator* NewIterator(const ReadOptions&) const;
+
+  // Returns a new iterator over the meta blocks defined for table.
+  Iterator* NewMetaIterator() const;
+
+  // Given a key, returns meta-block defined for table.
+  Status ReadMeta(const Slice& key, MetaBlock** meta) const;
 
   // Given a key, return an approximate byte offset in the file where
   // the data for that key begins (or would begin if the key were

--- a/include/leveldb/table_builder.h
+++ b/include/leveldb/table_builder.h
@@ -21,6 +21,7 @@ namespace leveldb {
 
 class BlockBuilder;
 class BlockHandle;
+class MetaBlockBuilder;
 class WritableFile;
 
 class TableBuilder {
@@ -40,6 +41,10 @@ class TableBuilder {
   // structure passed to this method, this method will return an error
   // without changing any fields.
   Status ChangeOptions(const Options& options);
+
+  // Add meta block with some user-defined data.
+  // REQUIRES: Finish(), Abandon() have not been called
+  void AddMetaBlock(MetaBlockBuilder* builder);
 
   // Add key,value to the table being constructed.
   // REQUIRES: key is after any previously added key according to comparator.


### PR DESCRIPTION
This is proposal for feature that allows users to store arbitrary meta blocks (stats or something) inside sstables:
- Low-level API includes TableBuilder::AddMetaBlock and Table::ReadMeta along with Table::NewMetaIterator.
- Mid-level API includes Version::VisitMeta that accepts visitor to visit all meta data blocks defined for this version. It also provides simple range-filter to visit only subset of sstables.
- High-level API not provided.
