### PR TITLE
Fix -Wunused-function warning in db_bench.cc

### DIFF
--- a/db/db_bench.cc
+++ b/db/db_bench.cc
@@ -139,6 +139,7 @@ class RandomGenerator {
   }
 };
 
+#if defined(__linux)
 static Slice TrimSpace(Slice s) {
   size_t start = 0;
   while (start < s.size() && isspace(s[start])) {
@@ -150,6 +151,7 @@ static Slice TrimSpace(Slice s) {
   }
   return Slice(s.data() + start, limit - start);
 }
+#endif
 
 static void AppendWithSpace(std::string* str, Slice msg) {
   if (msg.empty()) return;


### PR DESCRIPTION
This warning was recently enabled more widely in Chromium, and it fired on this
file:

../../third_party/leveldatabase/src/db/db_bench.cc(145,14):
error: unused function 'TrimSpace' [-Werror,-Wunused-function]
static Slice TrimSpace(Slice s) {
             ^