### PR TITLE
Add a function GetDbSize in db.h to get the total file size of database

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1400,6 +1400,21 @@ bool DBImpl::GetProperty(const Slice& property, std::string* value) {
   return false;
 }
 
+void GetDbSize(uint64_t* size) {
+  Version* v;
+  {
+    MutexLock l(&mutex_);
+    versions_->current()->Ref();
+    v = versions_->current();
+  }
+  *size = versions_->GetVersionDbSize(v);
+ 
+  {
+    MutexLock l(&mutex_);
+    v->Unref();
+  }
+}
+
 void DBImpl::GetApproximateSizes(
     const Range* range, int n,
     uint64_t* sizes) {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -41,6 +41,7 @@ class DBImpl : public DB {
   virtual bool GetProperty(const Slice& property, std::string* value);
   virtual void GetApproximateSizes(const Range* range, int n, uint64_t* sizes);
   virtual void CompactRange(const Slice* begin, const Slice* end);
+  virtual void GetDbSize(uint64_t* size);
 
   // Extra methods (for testing) that are not in the public DB interface
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1102,6 +1102,17 @@ const char* VersionSet::LevelSummary(LevelSummaryStorage* scratch) const {
   return scratch->buffer;
 }
 
+uint64_t VersionSet::GetVersionDbSize(Version* v) {
+  uint64_t result = 0;
+  for (int level = 0; level < config::kNumLevels; level++) {
+    const std::vector<FileMetaData*>& files = v->files_[level];
+    for (size_t i = 0; i < files.size(); i++) {
+        result += files[i]->file_size;
+      }
+    }
+  return result;
+}
+
 uint64_t VersionSet::ApproximateOffsetOf(Version* v, const InternalKey& ikey) {
   uint64_t result = 0;
   for (int level = 0; level < config::kNumLevels; level++) {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -261,6 +261,9 @@ class VersionSet {
   // "key" as of version "v".
   uint64_t ApproximateOffsetOf(Version* v, const InternalKey& key);
 
+  // Return the total file size of all level files
+  uint64_t VersionSet::GetVersionDbSize(Version* v);
+
   // Return a human-readable short (single-line) summary of the number
   // of files per level.  Uses *scratch as backing store.
   struct LevelSummaryStorage {

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -128,6 +128,15 @@ class DB {
   virtual void GetApproximateSizes(const Range* range, int n,
                                    uint64_t* sizes) = 0;
 
+  // Get the total file size of all level files
+  //
+  // Note that the returned sizes measure file system space usage, so
+  // if the user data compresses by a factor of ten, the returned
+  // sizes will be one-tenth the size of the corresponding user data size.
+  //
+  // The results may not include the sizes of recently written data.
+  virtual void GetDbSize(uint64_t* size) = 0;
+
   // Compact the underlying storage for the key range [*begin,*end].
   // In particular, deleted and overwritten versions are discarded,
   // and the data is rearranged to reduce the cost of operations


### PR DESCRIPTION
Fix for Issue 318: In some usercases, we need to get the totol file size of leveldb, and we
need to get this information in our C++ programs directly.
This commit add a new api in db.h, and really implemented in
db/version_set.cc.

Signed-off-by: mengshengzhi mengshengzhi@baidu.com
Signed-off-by: ketor d.ketor@gmail.com
