### PR TITLE
add travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 **LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.**
 
+[![Build Status](https://travis-ci.org/google/leveldb.svg?branch=master)](https://travis-ci.org/google/leveldb)
+
 Authors: Sanjay Ghemawat (sanjay@google.com) and Jeff Dean (jeff@google.com)
 
 # Features


### PR DESCRIPTION
If travis is used, it's common practice to put a badge in the `README`.