### PR TITLE
Fix snapshot compaction bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ if(LEVELDB_BUILD_TESTS)
 
   leveldb_test("${PROJECT_SOURCE_DIR}/issues/issue178_test.cc")
   leveldb_test("${PROJECT_SOURCE_DIR}/issues/issue200_test.cc")
+  leveldb_test("${PROJECT_SOURCE_DIR}/issues/issue320_test.cc")
 
   leveldb_test("${PROJECT_SOURCE_DIR}/util/env_test.cc")
   leveldb_test("${PROJECT_SOURCE_DIR}/util/status_test.cc")

--- a/issues/issue320_test.cc
+++ b/issues/issue320_test.cc
@@ -1,0 +1,139 @@
+// Copyright (c) 2019 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <map>
+#include <vector>
+#include <memory>
+
+#include <math.h>
+
+#include <leveldb/db.h>
+#include <leveldb/write_batch.h>
+#include <util/testharness.h>
+
+using namespace std;
+
+namespace leveldb {
+
+namespace {
+
+unsigned int random(unsigned int max) {
+  return std::rand() % max;
+}
+
+string newString(int32_t index) {
+  const unsigned int len = 1024;
+  char bytes[len];
+  unsigned int i = 0;
+  while (i < 8) {
+    bytes[i] = 'a' + ((index >> (4 * i)) & 0xf);
+    ++i;
+  }
+  while (i < sizeof(bytes)) {
+    bytes[i] = 'a' + random(26);
+    ++i;
+  }
+  return string(bytes, sizeof(bytes));
+}
+
+}  // namespace
+
+class Issue320 { };
+
+TEST(Issue320, Test) {
+  std::srand(0);
+
+  bool delete_before_put = false;
+  bool keep_snapshots = true;
+
+  vector<pair<string, string>*> test_map(10000, nullptr);
+  vector<Snapshot const*> snapshots(100, nullptr);
+
+  DB* db;
+  Options options;
+  options.create_if_missing = true;
+
+  std::string dbpath = test::TmpDir() + "/leveldb_issue320_test";
+  ASSERT_OK(DB::Open(options, dbpath, &db));
+
+  unsigned int target_size = 10000;
+  unsigned int num_items = 0;
+  unsigned long count = 0;
+  string key;
+  string value, old_value;
+
+  WriteOptions writeOptions;
+  ReadOptions readOptions;
+  while (count < 200000) {
+    if ((++count % 1000) == 0) {
+      cout << "count: " << count << endl;
+    }
+
+    unsigned int index = random(test_map.size());
+    WriteBatch batch;
+
+    if (test_map[index] == nullptr) {
+      num_items++;
+      test_map[index] =
+          new pair<string, string>(newString(index), newString(index));
+      batch.Put(test_map[index]->first, test_map[index]->second);
+    } else {
+      ASSERT_OK(db->Get(readOptions, test_map[index]->first, &old_value));
+      if (old_value != test_map[index]->second) {
+        cout << "ERROR incorrect value returned by Get" << endl;
+        cout << "  count=" << count << endl;
+        cout << "  old value=" << old_value << endl;
+        cout << "  test_map[index]->second=" << test_map[index]->second << endl;
+        cout << "  test_map[index]->first=" << test_map[index]->first << endl;
+        cout << "  index=" << index << endl;
+        ASSERT_EQ(old_value, test_map[index]->second);
+      }
+
+      if (num_items >= target_size && random(100) > 30) {
+        batch.Delete(test_map[index]->first);
+        delete test_map[index];
+        test_map[index] = nullptr;
+        --num_items;
+      } else {
+        test_map[index]->second = newString(index);
+        if (delete_before_put) batch.Delete(test_map[index]->first);
+        batch.Put(test_map[index]->first, test_map[index]->second);
+      }
+    }
+
+    ASSERT_OK(db->Write(writeOptions, &batch));
+
+    if (keep_snapshots && random(10) == 0) {
+      unsigned int i = random(snapshots.size());
+      if (snapshots[i] != nullptr) {
+        db->ReleaseSnapshot(snapshots[i]);
+      }
+      snapshots[i] = db->GetSnapshot();
+    }
+  }
+
+  for (Snapshot const* snapshot : snapshots) {
+    if (snapshot) {
+      db->ReleaseSnapshot(snapshot);
+    }
+  }
+
+  for (size_t i = 0; i < test_map.size(); ++i) {
+    if (test_map[i] != nullptr) {
+      delete test_map[i];
+      test_map[i] = nullptr;
+    }
+  }
+
+  delete db;
+  DestroyDB(dbpath, options);
+}
+
+}  // namespace leveldb
+
+int main(int argc, char** argv) {
+  return leveldb::test::RunAllTests();
+}


### PR DESCRIPTION
Closes google/leveldb#320

During compaction it was possible that records from a block b1=(l1,u1)
would be pushed down from level i to level i+1. If there is a block
b2=(l2,u2) at level i with k1 = user_key(u1) = user_key(l2) then
a subsequent search for k1 will yield the record l2 which has a smaller
sequence number than u1 because the sort order for records sorts
increasing by user key but decreaing by sequence number.

This change add a call to a new function AddBoundaryInputs to
SetupOtherInputs. AddBoundaryInputs searches for a block b2 matching the
criteria above and adds it to the set of files to be compacted. Whenever
AddBoundaryInputs is called it is important that the compaction fileset
in level i+1 (known as c->inputs_[1] in the code) be recomputed. Each
call to AddBoundaryInputs is followed by a call to GetOverlappingInputs.

SetupOtherInputs is called on both manual and automated compaction
passes. It is called for both level zero and for levels greater than 0.

Testing Done:

  A test program (issue320_test) was constructed that performs mutations
  while snapshots are active. issue320_test fails without this bug fix
  after 64k writes. It passes with this bug fix. It was run with 200M
  writes and passed.

  Unit tests were written for the new function that was added to the
  code. Make check was run and seen to pass.

Signed-off-by: Richard Cole richcole@amazon.com
