### PR TITLE
Remove const from Delete

### DIFF
--- a/db/snapshot.h
+++ b/db/snapshot.h
@@ -50,7 +50,7 @@ class SnapshotList {
     return s;
   }
 
-  void Delete(const SnapshotImpl* s) {
+  void Delete(SnapshotImpl* s) {
     assert(s->list_ == this);
     s->prev_->next_ = s->next_;
     s->next_->prev_ = s->prev_;


### PR DESCRIPTION
The Delete method clearly modifies the input list and is confusing being marked as const. In addition to modification through pointers, s is deleted. Perhaps New and Delete should be refactored into proper constructors/destructors.
