### PR TITLE
Fix signed/unsigned mismatch on VC++ builds

### DIFF
--- a/db/skiplist_test.cc
+++ b/db/skiplist_test.cc
@@ -250,7 +250,7 @@ class ConcurrentTest {
         // Note that generation 0 is never inserted, so it is ok if
         // <*,0,*> is missing.
         ASSERT_TRUE((gen(pos) == 0) ||
-                    (gen(pos) > initial_state.Get(key(pos)))
+                    (gen(pos) > static_cast<Key>(initial_state.Get(key(pos))))
                     ) << "key: " << key(pos)
                       << "; gen: " << gen(pos)
                       << "; initgen: "


### PR DESCRIPTION
This fixes a signed/unsigned mismatch on Windows/VC++ builds with VC++ 2013 and 2015. It happens when we do a 64-bit build of leveldb_skiplist_test, with this command:

    ninja -C out\Release_x64 leveldb_skiplist_test

The warning is:

    third_party\leveldatabase\src\db\skiplist_test.cc(252): warning C4018: '>': signed/unsigned mismatch

I am a Google employee and therefore approved for submitting PRs to this repo.