### PR TITLE
Update db_impl.cc

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -264,7 +264,9 @@ void DBImpl::DeleteObsoleteFiles() {
         Log(options_.info_log, "Delete type=%d #%lld\n",
             int(type),
             static_cast<unsigned long long>(number));
+        mutex_.Unlock();
         env_->DeleteFile(dbname_ + "/" + filenames[i]);
+        mutex_.Lock();
       }
     }
   }


### PR DESCRIPTION
 Read/Write requests are blocked shortly when leveldb is compacting. we found that the unlink 
function costs too much time in DeleteObsoleteFiles().  (unlink(sstableFile) cost 50ms , sstable 
size=256m), while unlink function doesn't need to acquire a lock.What's more, in 
DeleteObsoleteFiles(), unlink is called in a for loop,  which causes a much worse -- during this
 time, requests are blocked util the lock is released. It will improve levaldb's availability by adding 
unlock/lock before/after env_->DeleteFile() call. —— R&D Team of YY.inc Entertainment dept.
