### PR TITLE
Some cleanup of the util/coding library

### DIFF
--- a/util/coding.cc
+++ b/util/coding.cc
@@ -135,7 +135,7 @@ bool GetVarint32(Slice* input, uint32_t* value) {
   if (q == NULL) {
     return false;
   } else {
-    *input = Slice(q, limit - q);
+    input->remove_prefix(q - p);
     return true;
   }
 }
@@ -164,19 +164,9 @@ bool GetVarint64(Slice* input, uint64_t* value) {
   if (q == NULL) {
     return false;
   } else {
-    *input = Slice(q, limit - q);
+    input->remove_prefix(q - p);
     return true;
   }
-}
-
-const char* GetLengthPrefixedSlice(const char* p, const char* limit,
-                                   Slice* result) {
-  uint32_t len;
-  p = GetVarint32Ptr(p, limit, &len);
-  if (p == NULL) return NULL;
-  if (p + len > limit) return NULL;
-  *result = Slice(p, len);
-  return p + len;
 }
 
 bool GetLengthPrefixedSlice(Slice* input, Slice* result) {

--- a/util/coding_test.cc
+++ b/util/coding_test.cc
@@ -92,7 +92,7 @@ TEST(Coding, Varint32) {
     ASSERT_EQ(expected, actual);
     ASSERT_EQ(VarintLength(actual), p - start);
   }
-  ASSERT_EQ(p, s.data() + s.size());
+  ASSERT_EQ(p, limit);
 }
 
 TEST(Coding, Varint64) {


### PR DESCRIPTION
1) Removing the obselete api: GetLengthPrefixedSlice(const char*, const char*, Slice*)
as it's not referenced anywhere.
2) A small implementation tweak of GetVarint32/GetVarint64 api:advancing the
input slice past the parsed value using Slice::remove_prefix() instead of
reinitializing *input_slice object.
3) coding_test.cc update.

Test: make check; all tests passed.