### PR TITLE
documentation: fix incorrect log file default size

### DIFF
--- a/doc/impl.html
+++ b/doc/impl.html
@@ -24,7 +24,7 @@ There are several different types of files as documented below:
 <p>
 A log file (*.log) stores a sequence of recent updates.  Each update
 is appended to the current log file.  When the log file reaches a
-pre-determined size (approximately 4MB by default), it is converted
+pre-determined size (approximately 1MB by default), it is converted
 to a sorted table (see below) and a new log file is created for future
 updates.
 <p>


### PR DESCRIPTION
According to the rest of the documentation, a new sstable is created from the memtable when the log file grows to more than 1MB in size. 4MB is the threshold which triggers a level-0 compaction.
