### PR TITLE
broken db: fix assertion in leveldb::InternalKey::Encode, mark base as corrupt

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -150,7 +150,11 @@ class InternalKey {
     AppendInternalKey(&rep_, ParsedInternalKey(user_key, s, t));
   }
 
-  void DecodeFrom(const Slice& s) { rep_.assign(s.data(), s.size()); }
+  bool DecodeFrom(const Slice& s) {
+    rep_.assign(s.data(), s.size());
+    return !rep_.empty();
+  }
+
   Slice Encode() const {
     assert(!rep_.empty());
     return rep_;

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -88,8 +88,7 @@ void VersionEdit::EncodeTo(std::string* dst) const {
 static bool GetInternalKey(Slice* input, InternalKey* dst) {
   Slice str;
   if (GetLengthPrefixedSlice(input, &str)) {
-    dst->DecodeFrom(str);
-    return true;
+    return dst->DecodeFrom(str);
   } else {
     return false;
   }


### PR DESCRIPTION
```
Program received signal SIGABRT, Aborted.
__libc_do_syscall () at ../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:44
44      ../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S: No such file or directory.
#0  __libc_do_syscall () at ../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:44
#1  0xb6e11ebe in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#2  0xb6e14716 in __GI_abort () at abort.c:89
#3  0xb6e0d104 in __assert_fail_base (fmt=0x1 <error: Cannot access memory at address 0x1>, assertion=0x63210 "!rep_.empty()", assertion@entry=0x0,
    file=0x63220 "./db/dbformat.h", file@entry=0xb6ff9000 "", line=171, line@entry=3068948644,
    function=function@entry=0x634b8 <leveldb::InternalKey::Encode() const::__PRETTY_FUNCTION__> "leveldb::Slice leveldb::InternalKey::Encode() const") at assert.c:92
#4  0xb6e0d19a in __GI___assert_fail (assertion=0x0, file=0xb6ff9000 "", line=3068948644,
    function=0x634b8 <leveldb::InternalKey::Encode() const::__PRETTY_FUNCTION__> "leveldb::Slice leveldb::InternalKey::Encode() const") at assert.c:101
#5  0x00049962 in leveldb::InternalKey::Encode (this=0x857fc) at ./db/dbformat.h:171
#6  0x0004ecaa in leveldb::VersionSet::Builder::Apply (this=0xbefff13c, edit=0xbefff0d8) at db/version_set.cc:667
#7  0x0004c436 in leveldb::VersionSet::Recover (this=0x79d20, save_manifest=0xbefff317) at db/version_set.cc:963
#8  0x0003983a in leveldb::DBImpl::Recover (this=0x78350, edit=0xbefff330, save_manifest=0xbefff317) at db/db_impl.cc:303
#9  0x0003d7ae in leveldb::DB::Open (options=..., dbname="map.db", dbptr=0xbefff3a4) at db/db_impl.cc:1498
```
