### PR TITLE
Fix `make PLATFORM=IOS` by adding missing definition for `SHARED_OUTDIR`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ DEVICESDK=$(shell xcrun -sdk iphoneos --show-sdk-path)
 DEVICE_CFLAGS = -isysroot "$(DEVICESDK)" -arch armv6 -arch armv7 -arch armv7s -arch arm64
 SIMULATOR_CFLAGS = -isysroot "$(SIMULATORSDK)" -arch i686 -arch x86_64
 STATIC_OUTDIR=out-ios-universal
+SHARED_OUTDIR=out-shared
 else
 STATIC_OUTDIR=out-static
 SHARED_OUTDIR=out-shared


### PR DESCRIPTION
Previously, when we do `make PLATFORM=IOS`, the `SHARED_OUTDIR` is not defined, this will cause the output of the shared library to be the root directory of the building machine, which sometimes will result in an error due to the access was denied.

This pull request fixes this issue, and now `make PLATFORM=IOS` will run correctly.
