### PR TITLE
Remove extra new lines from logging

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -262,7 +262,7 @@ void DBImpl::DeleteObsoleteFiles() {
         if (type == kTableFile) {
           table_cache_->Evict(number);
         }
-        Log(options_.info_log, "Delete type=%d #%lld\n",
+        Log(options_.info_log, "Delete type=%d #%lld",
             int(type),
             static_cast<unsigned long long>(number));
         env_->DeleteFile(dbname_ + "/" + filenames[i]);
@@ -459,7 +459,7 @@ Status DBImpl::RecoverLogFile(uint64_t log_number, bool last_log,
     uint64_t lfile_size;
     if (env_->GetFileSize(fname, &lfile_size).ok() &&
         env_->NewAppendableFile(fname, &logfile_).ok()) {
-      Log(options_.info_log, "Reusing old log %s \n", fname.c_str());
+      Log(options_.info_log, "Reusing old log %s", fname.c_str());
       log_ = new log::Writer(logfile_, lfile_size);
       logfile_number_ = log_number;
       if (mem != NULL) {
@@ -702,7 +702,7 @@ void DBImpl::BackgroundCompaction() {
       manual_end = c->input(0, c->num_input_files(0) - 1)->largest;
     }
     Log(options_.info_log,
-        "Manual compaction at level-%d from %s .. %s; will stop at %s\n",
+        "Manual compaction at level-%d from %s .. %s; will stop at %s",
         m->level,
         (m->begin ? m->begin->DebugString().c_str() : "(begin)"),
         (m->end ? m->end->DebugString().c_str() : "(end)"),
@@ -726,7 +726,7 @@ void DBImpl::BackgroundCompaction() {
       RecordBackgroundError(status);
     }
     VersionSet::LevelSummaryStorage tmp;
-    Log(options_.info_log, "Moved #%lld to level-%d %lld bytes %s: %s\n",
+    Log(options_.info_log, "Moved #%lld to level-%d %lld bytes %s: %s",
         static_cast<unsigned long long>(f->number),
         c->level() + 1,
         static_cast<unsigned long long>(f->file_size),
@@ -1345,11 +1345,11 @@ Status DBImpl::MakeRoomForWrite(bool force) {
     } else if (imm_ != NULL) {
       // We have filled up the current memtable, but the previous
       // one is still being compacted, so we wait.
-      Log(options_.info_log, "Current memtable full; waiting...\n");
+      Log(options_.info_log, "Current memtable full; waiting...");
       bg_cv_.Wait();
     } else if (versions_->NumLevelFiles(0) >= config::kL0_StopWritesTrigger) {
       // There are too many level-0 files.
-      Log(options_.info_log, "Too many L0 files; waiting...\n");
+      Log(options_.info_log, "Too many L0 files; waiting...");
       bg_cv_.Wait();
     } else {
       // Attempt to switch to a new memtable and trigger compaction of old

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -447,7 +447,7 @@ class Repairer {
     new_file.append("/");
     new_file.append((slash == NULL) ? fname.c_str() : slash + 1);
     Status s = env_->RenameFile(fname, new_file);
-    Log(options_.info_log, "Archiving %s: %s\n",
+    Log(options_.info_log, "Archiving %s: %s",
         fname.c_str(), s.ToString().c_str());
   }
 };

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -870,7 +870,7 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
         s = descriptor_file_->Sync();
       }
       if (!s.ok()) {
-        Log(options_->info_log, "MANIFEST write: %s\n", s.ToString().c_str());
+        Log(options_->info_log, "MANIFEST write: %s", s.ToString().c_str());
       }
     }
 
@@ -1044,12 +1044,12 @@ bool VersionSet::ReuseManifest(const std::string& dscname,
   assert(descriptor_log_ == NULL);
   Status r = env_->NewAppendableFile(dscname, &descriptor_file_);
   if (!r.ok()) {
-    Log(options_->info_log, "Reuse MANIFEST: %s\n", r.ToString().c_str());
+    Log(options_->info_log, "Reuse MANIFEST: %s", r.ToString().c_str());
     assert(descriptor_file_ == NULL);
     return false;
   }
 
-  Log(options_->info_log, "Reusing MANIFEST %s\n", dscname.c_str());
+  Log(options_->info_log, "Reusing MANIFEST %s", dscname.c_str());
   descriptor_log_ = new log::Writer(descriptor_file_, manifest_size);
   manifest_file_number_ = manifest_number;
   return true;
@@ -1371,7 +1371,7 @@ void VersionSet::SetupOtherInputs(Compaction* c) {
                                      &expanded1);
       if (expanded1.size() == c->inputs_[1].size()) {
         Log(options_->info_log,
-            "Expanding@%d %d+%d (%ld+%ld bytes) to %d+%d (%ld+%ld bytes)\n",
+            "Expanding@%d %d+%d (%ld+%ld bytes) to %d+%d (%ld+%ld bytes)",
             level,
             int(c->inputs_[0].size()),
             int(c->inputs_[1].size()),


### PR DESCRIPTION
The built-in logger strips new lines if they are included, however,
in the case when another application is consuming the logs (such as
Ceph), it will get some log lines with new lines and some without.

This patch removes a large majority of new lines in an attempt to
make logging always consistently deliver messages without new lines.
