### PR TITLE
Fix build on Windows for Visual Studio 2015

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -5,7 +5,6 @@
 #include "leveldb/c.h"
 
 #include <stdlib.h>
-#include <unistd.h>
 #include "leveldb/cache.h"
 #include "leveldb/comparator.h"
 #include "leveldb/db.h"

--- a/port/port.h
+++ b/port/port.h
@@ -16,6 +16,8 @@
 #  include "port/port_chromium.h"
 #elif defined(LEVELDB_PLATFORM_ANDROID)
 #  include "port/port_android.h"
+#elif defined(LEVELDB_PLATFORM_WINDOWS)
+#  include "port/port_win.h"
 #endif
 
 #endif  // STORAGE_LEVELDB_PORT_PORT_H_

--- a/port/port_win.h
+++ b/port/port_win.h
@@ -31,7 +31,9 @@
 #ifndef STORAGE_LEVELDB_PORT_PORT_WIN_H_
 #define STORAGE_LEVELDB_PORT_PORT_WIN_H_
 
-#define snprintf _snprintf
+#if (_MSC_VER < 1900)
+#  define snprintf _snprintf
+#endif
 #define close _close
 #define fread_unlocked _fread_nolock
 


### PR DESCRIPTION
Little fixes that enable building leveldb on Windows with Visual Studio 2015:
- unistd.h is unavailable on this platform, but was not needed for build even on Linux
- port_win.h was not included in port.h
- snprintf has been added into VS2015, the macro <<#define snprintf _snprintf>>prevents the build on VS2015