### PR TITLE
add leveldb_options_set_max_file_size to C bindings

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -446,6 +446,10 @@ void leveldb_options_set_block_restart_interval(leveldb_options_t* opt, int n) {
   opt->rep.block_restart_interval = n;
 }
 
+void leveldb_options_set_max_file_size(leveldb_options_t* opt, size_t s) {
+  opt->rep.max_file_size = s;
+}
+
 void leveldb_options_set_compression(leveldb_options_t* opt, int t) {
   opt->rep.compression = static_cast<CompressionType>(t);
 }

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -189,6 +189,7 @@ int main(int argc, char** argv) {
   leveldb_options_set_max_open_files(options, 10);
   leveldb_options_set_block_size(options, 1024);
   leveldb_options_set_block_restart_interval(options, 8);
+  leveldb_options_set_max_file_size(options, 16<<20);
   leveldb_options_set_compression(options, leveldb_no_compression);
 
   roptions = leveldb_readoptions_create();

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -199,6 +199,7 @@ extern void leveldb_options_set_max_open_files(leveldb_options_t*, int);
 extern void leveldb_options_set_cache(leveldb_options_t*, leveldb_cache_t*);
 extern void leveldb_options_set_block_size(leveldb_options_t*, size_t);
 extern void leveldb_options_set_block_restart_interval(leveldb_options_t*, int);
+extern void leveldb_options_set_max_file_size(leveldb_options_t*, size_t);
 
 enum {
   leveldb_no_compression = 0,


### PR DESCRIPTION
- makes the new max_file_size option available from C
- closes #439