### PR TITLE
Wish to add DB::SuspendCompactions() and DB:: ResumeCompactions() methods

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -125,6 +125,8 @@ DBImpl::DBImpl(const Options& raw_options, const std::string& dbname)
       dbname_(dbname),
       db_lock_(NULL),
       shutting_down_(NULL),
+      suspend_cv(&suspend_mutex),
+      suspend_count(0),
       bg_cv_(&mutex_),
       mem_(NULL),
       imm_(NULL),
@@ -1470,6 +1472,32 @@ void DBImpl::GetApproximateSizes(
     v->Unref();
   }
 }
+
+
+void DBImpl::SuspendCompactions() {
+  MutexLock l(& suspend_mutex);
+  env_->Schedule(&SuspendWork, this);
+  while( suspend_count < 1 ) {
+    suspend_cv.Wait();
+  }  
+}
+void DBImpl::SuspendWork(void* db) {
+  reinterpret_cast<DBImpl*>(db)->SuspendCallback();
+}
+void DBImpl::SuspendCallback() {
+    MutexLock l(&suspend_mutex);
+    suspend_count++;
+    suspend_cv.SignalAll();
+    while( suspend_count > 0 ) {
+        suspend_cv.Wait();
+    }
+}
+void DBImpl::ResumeCompactions() {
+    MutexLock l(&suspend_mutex);
+    suspend_count--;
+    suspend_cv.SignalAll();
+}
+
 
 // Default implementations of convenience methods that subclasses of DB
 // can call if they wish

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -139,6 +139,7 @@ class DBImpl : public DB {
   port::Mutex suspend_mutex;
   port::CondVar suspend_cv;
   int suspend_count;
+  bool suspended;
   static void SuspendWork(void* db);
   void SuspendCallback();
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -42,6 +42,9 @@ class DBImpl : public DB {
   virtual void GetApproximateSizes(const Range* range, int n, uint64_t* sizes);
   virtual void CompactRange(const Slice* begin, const Slice* end);
 
+  virtual void SuspendCompactions();
+  virtual void ResumeCompactions();
+
   // Extra methods (for testing) that are not in the public DB interface
 
   // Compact any files in the named level that overlap [*begin,*end]
@@ -132,6 +135,12 @@ class DBImpl : public DB {
 
   // Lock over the persistent DB state.  Non-NULL iff successfully acquired.
   FileLock* db_lock_;
+
+  port::Mutex suspend_mutex;
+  port::CondVar suspend_cv;
+  int suspend_count;
+  static void SuspendWork(void* db);
+  void SuspendCallback();
 
   // State below is protected by mutex_
   port::Mutex mutex_;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -1866,6 +1866,10 @@ class ModelDB: public DB {
 
   explicit ModelDB(const Options& options): options_(options) { }
   ~ModelDB() { }
+
+  virtual void SuspendCompactions() {}
+  virtual void ResumeCompactions() {}
+
   virtual Status Put(const WriteOptions& o, const Slice& k, const Slice& v) {
     return DB::Put(o, k, v);
   }

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -142,6 +142,12 @@ class DB {
   //    db->CompactRange(NULL, NULL);
   virtual void CompactRange(const Slice* begin, const Slice* end) = 0;
 
+  // Suspends the background compaction thread.  This methods
+  // returns once suspended.
+  virtual void SuspendCompactions() = 0;
+  // Resumes a suspended background compation thread.
+  virtual void ResumeCompactions() = 0;
+
  private:
   // No copying allowed
   DB(const DB&);

--- a/port/atomic_pointer.h
+++ b/port/atomic_pointer.h
@@ -39,8 +39,10 @@
 #define ARCH_CPU_ARM64_FAMILY 1
 #elif defined(__ppc__) || defined(__powerpc__) || defined(__powerpc64__)
 #define ARCH_CPU_PPC_FAMILY 1
-#elif defined(__mips__) || defined(__mips64__)
+#elif defined(__mips__)
 #define ARCH_CPU_MIPS_FAMILY 1
+#elif defined(__mips64el__)
+#define ARCH_CPU_MIPS64EL_FAMILY 1
 #endif
 
 namespace leveldb {
@@ -116,6 +118,13 @@ inline void MemoryBarrier() {
 #elif defined(ARCH_CPU_MIPS_FAMILY) && defined(__GNUC__)
 inline void MemoryBarrier() {
   __asm__ __volatile__("sync" : : : "memory");
+}
+#define LEVELDB_HAVE_MEMORY_BARRIER
+
+// MIPS64EL
+#elif defined(ARCH_CPU_MIPS64EL_FAMILY)
+inline void MemoryBarrier() {
+  asm volatile("dmb sy" : : : "memory");
 }
 #define LEVELDB_HAVE_MEMORY_BARRIER
 

--- a/port/atomic_pointer.h
+++ b/port/atomic_pointer.h
@@ -39,7 +39,7 @@
 #define ARCH_CPU_ARM64_FAMILY 1
 #elif defined(__ppc__) || defined(__powerpc__) || defined(__powerpc64__)
 #define ARCH_CPU_PPC_FAMILY 1
-#elif defined(__mips__)
+#elif defined(__mips__) || defined(__mips64__)
 #define ARCH_CPU_MIPS_FAMILY 1
 #endif
 


### PR DESCRIPTION
My team created a leveldbjni-1.8.jar supporting aarch64, but we found that leveldb has no members named 'ResumeCompactions' and 'SuspendCompactions' when building leveldbjni.
So we made some changes to leveldb refering to https://github.com/ibmsoe/leveldb ,and then we are successful.
Can you please add the methods to leveldb?
Thanks!