### PR TITLE
Remove compiler warning in logging.cc

### DIFF
--- a/util/logging.cc
+++ b/util/logging.cc
@@ -52,7 +52,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
     char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
-      const int delta = (c - '0');
+      const unsigned int delta = (c - '0');
       static const uint64_t kMaxUint64 = ~static_cast<uint64_t>(0);
       if (v > kMaxUint64/10 ||
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {


### PR DESCRIPTION
There is an unsigned vs signed comparison warning in logging.cc.  This should remove it.  It is already guaranteed to be a positive number from the condition on line 53 where c is already known to be between '0' and '9', so c will be in the range of 0 to 9.