### PR TITLE
Suggestion about AcceleratedCRC32C()

### DIFF
--- a/port/port_posix_sse.cc
+++ b/port/port_posix_sse.cc
@@ -93,7 +93,7 @@ uint32_t AcceleratedCRC32C(uint32_t crc, const char* buf, size_t size) {
 
   if (size > 16) {
     // Process unaligned bytes
-    for (unsigned int i = reinterpret_cast<uintptr_t>(p) % 8; i; --i) {
+    for (unsigned int i = reinterpret_cast<uintptr_t>(p) % 8; i && (i<8); i++) {
       STEP1;
     }
 


### PR DESCRIPTION
I think the Process(unaligned bytes) in function in file port_posix_sse.cc maybe wrong. 
The original code does m times STEP1, where m = p%8.
If p=10,then m=2,and the new p will be equal to 12, which is not aligned by 8. 
Thannks for reading.