### PR TITLE
Persistent Snapshots

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -918,7 +918,7 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
   if (!persistent_snapshots_.empty() &&  (persistent_snapshots_.oldest()->number_ < oldestSequence) ){
 	  oldestSequence = persistent_snapshots_.oldest()->number_;
   }
-  compact->smallest_snapshot = snapshots_.oldest()->number_;
+  compact->smallest_snapshot = oldestSequence;
 
   // Release mutex while we're actually doing the compaction work
   mutex_.Unlock();

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -151,7 +151,7 @@ DBImpl::DBImpl(const Options& raw_options, const std::string& dbname)
 	  std::string sequenceStr;
 	  while ((pos = persistenSnapshotData.find("\n")) != std::string::npos) {
 		  sequenceStr = persistenSnapshotData.substr(0, pos);
-		  persistent_snapshots_.New(std::atoll(sequenceStr.c_str()));
+		  persistent_snapshots_.New(atoll(sequenceStr.c_str()));
 		  persistenSnapshotData.erase(0, pos + 1);
 	  }
   }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -38,6 +38,9 @@ class DBImpl : public DB {
   virtual Iterator* NewIterator(const ReadOptions&);
   virtual const Snapshot* GetSnapshot();
   virtual void ReleaseSnapshot(const Snapshot* snapshot);
+  virtual Status PersistSnapshot(const Options& options, const Snapshot* s, std::string* snapshotID);
+  virtual Status UnpersistSnapshot(const Options& options, const Snapshot* s);
+  virtual const Snapshot* GetPersistedSnapshot (std::string snapshotID) ;
   virtual bool GetProperty(const Slice& property, std::string* value);
   virtual void GetApproximateSizes(const Range* range, int n, uint64_t* sizes);
   virtual void CompactRange(const Slice* begin, const Slice* end);
@@ -150,6 +153,8 @@ class DBImpl : public DB {
   WriteBatch* tmp_batch_;
 
   SnapshotList snapshots_;
+  SnapshotList persistent_snapshots_;
+
 
   // Set of table files to protect from deletion because they are
   // part of ongoing compactions.

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2046,6 +2046,17 @@ class ModelDB: public DB {
   virtual void CompactRange(const Slice* start, const Slice* end) {
   }
 
+  virtual Status PersistSnapshot(const Options& options, const Snapshot* s, std::string* snapshotID) {
+	  return Status::OK();
+  }
+
+  virtual Status UnpersistSnapshot(const Options& options, const Snapshot* s) {
+	  return Status::OK();
+  }
+
+  virtual const Snapshot* GetPersistedSnapshot (std::string snapshotID) {
+  }
+
  private:
   class ModelIter: public Iterator {
    public:

--- a/db/filename.cc
+++ b/db/filename.cc
@@ -69,6 +69,9 @@ std::string OldInfoLogFileName(const std::string& dbname) {
   return dbname + "/LOG.old";
 }
 
+std::string SnapshotFileName(const std::string& dbname) {
+  return dbname + "/SNAPSHOTS";
+}
 
 // Owned filenames have the form:
 //    dbname/CURRENT
@@ -90,6 +93,9 @@ bool ParseFileName(const std::string& fname,
   } else if (rest == "LOG" || rest == "LOG.old") {
     *number = 0;
     *type = kInfoLogFile;
+  } else if (rest == "SNAPSHOTS") {
+	  *number = 0;
+	  *type = kSnapshotsFile;
   } else if (rest.starts_with("MANIFEST-")) {
     rest.remove_prefix(strlen("MANIFEST-"));
     uint64_t num;

--- a/db/filename.h
+++ b/db/filename.h
@@ -24,7 +24,8 @@ enum FileType {
   kDescriptorFile,
   kCurrentFile,
   kTempFile,
-  kInfoLogFile  // Either the current one, or an old one
+  kInfoLogFile,  // Either the current one, or an old one
+  kSnapshotsFile, 
 };
 
 // Return the name of the log file with the specified number
@@ -66,6 +67,9 @@ extern std::string InfoLogFileName(const std::string& dbname);
 
 // Return the name of the old info log file for "dbname".
 extern std::string OldInfoLogFileName(const std::string& dbname);
+
+extern std::string SnapshotFileName(const std::string& dbname);
+
 
 // If filename is a leveldb file, store the type of the file in *type.
 // The number encoded in the filename is stored in *number.  If the

--- a/db/snapshot.h
+++ b/db/snapshot.h
@@ -50,12 +50,77 @@ class SnapshotList {
     return s;
   }
 
+// inserts a new snapshot according to its sequence number into the ordered list
+  const SnapshotImpl* Insert(SequenceNumber seq) {
+	  if (empty()) {
+		  return New (seq);
+	  }
+
+	  // iterate over last until an existing snapshot with larger sequence number is
+	   SnapshotImpl *s = list_.next_;
+		while (true) {
+			if (s->number_ > seq) {
+				// insert before
+				SnapshotImpl* newSnapShot = new SnapshotImpl;
+
+				newSnapShot->number_ = seq;
+				newSnapShot->list_ = this;
+				s->prev_->next_ = newSnapShot;
+				newSnapShot->prev_ = s->prev_;
+				newSnapShot->next_ = s;
+				s->prev_ = newSnapShot;
+				return newSnapShot;
+			}
+			if (s->next_ == (SnapshotImpl*) s->list_) {
+				break;
+			}
+			s = s->next_;
+		}
+	 return New (seq);
+  }
+
   void Delete(const SnapshotImpl* s) {
     assert(s->list_ == this);
     s->prev_->next_ = s->next_;
     s->next_->prev_ = s->prev_;
     delete s;
   }
+
+  // return existing snapshot with sequence number
+  SnapshotImpl* Get(SequenceNumber seq) {
+	  if (empty()) {
+		  return NULL;
+	  }
+	  SnapshotImpl *s = list_.next_;
+	  while (true) {
+		  if (s->number_ == seq) {
+			  return s;
+		  }
+		  if (s->next_ == (SnapshotImpl*) s->list_) {
+			  break;
+		  }
+		  s = s->next_;
+	  }
+	  return NULL;
+  }
+
+	std::string GetSequenceStringWithDelimiter(std::string delimiter) {
+		std::string result = "";
+
+		if (empty()) {
+			return result;
+		}
+		
+		SnapshotImpl *s = list_.next_;
+		while (true) {
+			result += NumberToString (s->number_) + delimiter;
+			if (s->next_ == (SnapshotImpl*) s->list_) {
+				break;
+			}
+			s = s->next_;
+		}
+		return result;
+	}
 
  private:
   // Dummy head of doubly-linked list of snapshots

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -102,6 +102,22 @@ class LEVELDB_EXPORT DB {
   // use "snapshot" after this call.
   virtual void ReleaseSnapshot(const Snapshot* snapshot) = 0;
 
+  // Marks an existing snapshot, that was previoulsy obtained via GetSnapshot(),
+  // as persistent. Use the returned snapshotID as param to GetPersisentSnapshot()
+  // to obtained the snapshot again after the database has been closed and
+  // re-openend. You still need to call ReleaseSnapskhot() after this call.
+  virtual Status PersistSnapshot(const Options& options, const Snapshot* s, std::string* snapshotID) = 0;
+
+  // Marks an previously pesistent snapshot as transient again, freeing up the
+  // storage occupied by it. You still need to call ReleaseSnapshot() after this call.
+  virtual Status UnpersistSnapshot(const Options& options, const Snapshot* s) = 0;
+
+  // Return a handle to a snapshot previously persisted with PersistSnapshot()
+  // using the saved snapshotID. You need to dispose of the returned value
+  // via ReleaseSnapshot(). The snapshot will remain persistant until you call
+  // UnpersistSnapshot(), though.
+  virtual const Snapshot* GetPersistedSnapshot (std::string snapshotID) = 0;
+
   // DB implementations can export properties about their state
   // via this method.  If "property" is a valid property understood by this
   // DB implementation, fills "*value" with its current value and returns


### PR DESCRIPTION
This PR adds to ability to persist snapshots across application sessions.

This feature can be very useful, if you have a long running operations (e.g. syncing a multi-GB database to the cloud), but the user has the ability to kill your app.  