### PR TITLE
Fix TargetFileSize() mixed unsigned/signed warning

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -20,7 +20,7 @@
 
 namespace leveldb {
 
-static int TargetFileSize(const Options* options) {
+static size_t TargetFileSize(const Options* options) {
   return options->max_file_size;
 }
 


### PR DESCRIPTION
This fixes a minor compiler warning when building with GCC 7.3. This is the only warning when building the project itself, there are some other warnings when building the test cases that I didn't look into.