### PR TITLE
Avoid a binary search overflow bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,5 +8,6 @@ Jeffrey Dean <jeff@google.com>
 Sanjay Ghemawat <sanjay@google.com>
 
 # Partial list of contributors:
+Dong-hee Na <donghee.na92@gmail.com>
 Kevin Regan <kevin.d.regan@gmail.com>
 Johan Bilien <jobi@litl.com>

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -89,7 +89,7 @@ int FindFile(const InternalKeyComparator& icmp,
   uint32_t left = 0;
   uint32_t right = files.size();
   while (left < right) {
-    uint32_t mid = (left + right) / 2;
+    uint32_t mid = ((uint64_t)left + (uint64_t)right) >> 1;
     const FileMetaData* f = files[mid];
     if (icmp.InternalKeyComparator::Compare(f->largest.Encode(), key) < 0) {
       // Key at "mid.largest" is < "target".  Therefore all

--- a/table/block.cc
+++ b/table/block.cc
@@ -168,7 +168,7 @@ class Block::Iter : public Iterator {
     uint32_t left = 0;
     uint32_t right = num_restarts_ - 1;
     while (left < right) {
-      uint32_t mid = (left + right + 1) / 2;
+      uint32_t mid = ((uint64_t)left + (uint64_t)right + (uint64_t)1) >> 1;
       uint32_t region_offset = GetRestartPoint(mid);
       uint32_t shared, non_shared, value_length;
       const char* key_ptr = DecodeEntry(data_ + region_offset,


### PR DESCRIPTION
Some of the codes are using binary search which has a possibility of the overflow bug.
Since num_restarts_ is uint32_t and std::vector.size() is size_t type.

ref: https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html