### PR TITLE
Sync MANIFEST file when creating a NewDB

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -196,6 +196,9 @@ Status DBImpl::NewDB() {
     new_db.EncodeTo(&record);
     s = log.AddRecord(record);
     if (s.ok()) {
+      s = file->Sync(); 
+    }
+    if (s.ok()) {
       s = file->Close();
     }
   }


### PR DESCRIPTION
I was observing failures reopening a database after a failure shortly after creating it.
 "Corruption: no meta-nextfile entry in descriptor".  
This appears to have fixed the problem.

This appears to be already reported as issue https://github.com/google/leveldb/issues/189