### PR TITLE
Use of CMAKE_INSTALL_INCLUDEDIR before inclusion of GNUInstallDirs.cmake gives bogus leveldb import target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,8 +189,15 @@ target_sources(leveldb
 target_include_directories(leveldb
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+if(LEVELDB_INSTALL)
+  include(GNUInstallDirs)
+  target_include_directories(leveldb
+    PUBLIC
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+endif(LEVELDB_INSTALL)
+
 target_compile_definitions(leveldb
   PRIVATE
     # Used by include/export.h when building shared libraries.


### PR DESCRIPTION
CMAKE_INSTALL_INCLUDEDIR was being used to set a leveldb target property for the INSTALL_INTERFACE. This variable is defined in the GNUInstallDirs module, which hadn't been included at that point. Since the variable was empty, no INTERFACE_INCLUDE_DIRECTORIES property was defined on the installed leveldb::leveldb import target, making it hard to use that target properly in importing CMake setups.