### PR TITLE
Support for Bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,8 @@
+config_setting(
+    name = "osx_x86_64",
+    constraint_values = [
+        "@bazel_tools//platforms:osx",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/db/BUILD
+++ b/db/BUILD
@@ -1,0 +1,103 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "db",
+    srcs = glob(
+        ["*.cc"],
+        exclude = glob([
+            "*_test.cc",
+            "leveldbutil.cc",
+            "db_bench.cc",
+        ]),
+    ),
+    hdrs = glob([
+        "*.h",
+    ]),
+    deps = [
+        "//include/leveldb",
+        "//table",
+        "//util",
+    ],
+)
+
+cc_binary(
+    name = "leveldbutil",
+    srcs = ["leveldbutil.cc"],
+    deps = [
+        ":db",
+        "//include/leveldb",
+        "//util",
+    ],
+)
+
+cc_test(
+    name = "autocompact_test",
+    srcs = ["autocompact_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "corruption_test",
+    srcs = ["corruption_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "db_test",
+    srcs = ["db_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "dbformat_test",
+    srcs = ["dbformat_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "fault_injection_test",
+    srcs = ["fault_injection_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "filename_test",
+    srcs = ["filename_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "log_test",
+    srcs = ["log_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "recovery_test",
+    srcs = ["recovery_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "skiplist_test",
+    srcs = ["skiplist_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "version_edit_test",
+    srcs = ["version_edit_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "write_batch_test",
+    srcs = ["write_batch_test.cc"],
+    deps = [":db"],
+)
+
+cc_test(
+    name = "version_set_test",
+    srcs = ["version_set_test.cc"],
+    deps = [":db"],
+)

--- a/include/leveldb/BUILD
+++ b/include/leveldb/BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "leveldb",
+    hdrs = glob(["*.h"]),
+    include_prefix = "leveldb",
+)

--- a/port/BUILD
+++ b/port/BUILD
@@ -1,0 +1,35 @@
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "osx_x86_64",
+    constraint_values = [
+        "@bazel_tools//platforms:osx",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "port",
+    hdrs = glob(["*.h"]),
+    defines = select({
+        ":osx_x86_64": [
+            "LEVELDB_PLATFORM_POSIX=1",
+            "LEVELDB_IS_BIG_ENDIAN=0",
+        ],
+        ":linux_x86_64": [
+            "LEVELDB_PLATFORM_POSIX=1",
+            "LEVELDB_IS_BIG_ENDIAN=0",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/table/BUILD
+++ b/table/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "table",
+    srcs = glob(
+        ["*.cc"],
+        exclude = glob(["*_test.cc"]),
+    ),
+    hdrs = glob(["*.h"]),
+    deps = [
+        "//include/leveldb",
+        "//util",
+    ],
+)
+
+cc_test(
+    name = "table_test",
+    srcs = ["table_test.cc"],
+    deps = [
+        ":table",
+        "//db",
+    ],
+)
+
+cc_test(
+    name = "filter_block_test",
+    srcs = ["filter_block_test.cc"],
+    deps = [
+        ":table",
+        "//db",
+    ],
+)

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,0 +1,84 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "util",
+    srcs = glob(
+        ["*.cc"],
+        exclude = glob(["*_test.cc"]),
+    ),
+    hdrs = glob(["*.h"]),
+    linkopts = select({
+        "//port:osx_x86_64": [],
+        "//port:linux_x86_64": [
+            "-pthread",
+        ],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//include/leveldb",
+        "//port",
+    ],
+)
+
+cc_test(
+    name = "arena_test",
+    srcs = ["arena_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "bloom_test",
+    srcs = ["bloom_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "cache_test",
+    srcs = ["cache_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "coding_test",
+    srcs = ["coding_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "crc32c_test",
+    srcs = ["crc32c_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "env_posix_test",
+    srcs = ["env_posix_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "env_test",
+    srcs = ["env_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "hash_test",
+    srcs = ["hash_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "logging_test",
+    srcs = ["logging_test.cc"],
+    deps = [":util"],
+)
+
+cc_test(
+    name = "status_test",
+    srcs = ["status_test.cc"],
+    deps = [
+        ":util",
+        "//include/leveldb",
+    ],
+)


### PR DESCRIPTION
Tested on Bazel 0.14, Apple LLVM version 9.0.0 (clang-900.0.39.2), OSX 10.12.6
Tested on Bazel 0.15.1, clang 3.8.1-24, Debian GNU/Linux 9.4 (stretch)

Outstanding:

* No support for snappy compression or crc32c acceleration (yet)

* Windows support needs at least modification of port/BUILD

* Does not enable LTO Visibility (driven by include/leveldb/export.h)

bazel test ...

//db:autocompact_test                      PASSED in 27.0s
//db:corruption_test                       PASSED in 5.0s
//db:db_test                               PASSED in 112.4s
//db:dbformat_test                         PASSED in 1.0s
//db:fault_injection_test                  PASSED in 9.5s
//db:filename_test                         PASSED in 0.5s
//db:log_test                              PASSED in 1.5s
//db:recovery_test                         PASSED in 0.3s
//db:skiplist_test                         PASSED in 37.7s
//db:version_edit_test                     PASSED in 0.7s
//db:version_set_test                      PASSED in 0.2s
//db:write_batch_test                      PASSED in 0.2s
//table:filter_block_test                  PASSED in 0.0s
//table:table_test                         PASSED in 14.3s
//util:arena_test                          PASSED in 1.1s
//util:bloom_test                          PASSED in 0.1s
//util:cache_test                          PASSED in 0.0s
//util:coding_test                         PASSED in 0.1s
//util:crc32c_test                         PASSED in 0.0s
//util:env_posix_test                      PASSED in 0.0s
//util:env_test                            PASSED in 0.8s
//util:hash_test                           PASSED in 0.0s
//util:logging_test                        PASSED in 0.0s
//util:status_test                         PASSED in 0.2s

Executed 24 out of 24 tests: 24 tests pass.
INFO: Build completed successfully, 220 total actions