### PR TITLE
Increase maximum read-only mmap()s used from 1000 to 4096 on 64-bit systems

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -575,8 +575,8 @@ static int MaxMmaps() {
   if (mmap_limit >= 0) {
     return mmap_limit;
   }
-  // Up to 1000 mmaps for 64-bit binaries; none for smaller pointer sizes.
-  mmap_limit = sizeof(void*) >= 8 ? 1000 : 0;
+  // Up to 4096 mmaps for 64-bit binaries; none for smaller pointer sizes.
+  mmap_limit = sizeof(void*) >= 8 ? 4096 : 0;
   return mmap_limit;
 }
 


### PR DESCRIPTION
By default LevelDB will only mmap() up to 1000 ldb files for reading and then fall back
to using file desciptors.

The typical linux system has a 'vm.max_map_count = 65530', so mapping only 1000 files
seems arbitarily small. Increase this value to another arbitrarily small value, 4096.

See also: https://github.com/bitcoin-core/leveldb/pull/19