### PR TITLE
log_writer: conditional flush with less disk I/O.

### DIFF
--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -100,7 +100,7 @@ Status Writer::EmitPhysicalRecord(RecordType t, const char* ptr, size_t n) {
   Status s = dest_->Append(Slice(buf, kHeaderSize));
   if (s.ok()) {
     s = dest_->Append(Slice(ptr, n));
-    if (s.ok()) {
+    if (s.ok() && (t == kLastType || t == kFullType)) {
       s = dest_->Flush();
     }
   }


### PR DESCRIPTION
Here changed the flush strategy, just flush into disk when
the record type is kFullType and kLastType. For the small
size content, it would flush as before. To the larger size
content acrossed several Blocks, it uses less disk I/O.

Signed-off-by: JiYou <jiyou09@gmail.com>