### PR TITLE
log_reader: Don't search a block if 6 bytes left in a block.

### DIFF
--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -38,7 +38,8 @@ bool Reader::SkipToInitialBlock() {
   uint64_t block_start_location = initial_offset_ - offset_in_block;
 
   // Don't search a block if we'd be in the trailer
-  if (offset_in_block > kBlockSize - 6) {
+  const int leftover = kBlockSize - offset_in_block;
+  if (leftover < kHeaderSize) {
     block_start_location += kBlockSize;
   }
 


### PR DESCRIPTION
When there are 6 bytes:
* in the middle of record
* \x00 filled by the log_writer
so, if initial_offset_ is 6 bytes left, need to skip this block.

By the way, change the magic number 6 to kHeaderSize.

Signed-off-by: JiYou <jiyou09@gmail.com>