### PR TITLE
C api: Add support to open/close/create_iter on table.

### DIFF
--- a/db/c_test.c
+++ b/db/c_test.c
@@ -146,6 +146,7 @@ unsigned char FilterKeyMatch(
 
 int main(int argc, char** argv) {
   leveldb_t* db;
+  leveldb_table_t* table;
   leveldb_comparator_t* cmp;
   leveldb_cache_t* cache;
   leveldb_env_t* env;
@@ -268,6 +269,14 @@ int main(int argc, char** argv) {
     leveldb_iter_destroy(iter);
   }
 
+  StartPhase("open table");
+  {
+    char tablepath[128];
+    snprintf(tablepath, 128, "%s/000005.ldb", dbname);
+    table = leveldb_table_open(leveldb_options_create(), tablepath, &err);
+    CheckNoError(err);
+  }
+
   StartPhase("approximate_sizes");
   {
     int i;
@@ -373,6 +382,7 @@ int main(int argc, char** argv) {
 
   StartPhase("cleanup");
   leveldb_close(db);
+  leveldb_table_close(table);
   leveldb_options_destroy(options);
   leveldb_readoptions_destroy(roptions);
   leveldb_writeoptions_destroy(woptions);

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -52,6 +52,7 @@ extern "C" {
 /* Exported types */
 
 typedef struct leveldb_t               leveldb_t;
+typedef struct leveldb_table_t         leveldb_table_t;
 typedef struct leveldb_cache_t         leveldb_cache_t;
 typedef struct leveldb_comparator_t    leveldb_comparator_t;
 typedef struct leveldb_env_t           leveldb_env_t;
@@ -73,7 +74,12 @@ typedef struct leveldb_writeoptions_t  leveldb_writeoptions_t;
 LEVELDB_EXPORT leveldb_t* leveldb_open(const leveldb_options_t* options,
                                        const char* name, char** errptr);
 
+LEVELDB_EXPORT leveldb_table_t* leveldb_table_open(const leveldb_options_t* options,
+                                                   const char* fname, char** errptr);
+
 LEVELDB_EXPORT void leveldb_close(leveldb_t* db);
+
+LEVELDB_EXPORT void leveldb_table_close(leveldb_table_t* table);
 
 LEVELDB_EXPORT void leveldb_put(leveldb_t* db,
                                 const leveldb_writeoptions_t* options,
@@ -98,6 +104,9 @@ LEVELDB_EXPORT char* leveldb_get(leveldb_t* db,
 
 LEVELDB_EXPORT leveldb_iterator_t* leveldb_create_iterator(
     leveldb_t* db, const leveldb_readoptions_t* options);
+
+LEVELDB_EXPORT leveldb_iterator_t* leveldb_table_create_iterator(
+    leveldb_table_t* table, const leveldb_readoptions_t* options);
 
 LEVELDB_EXPORT const leveldb_snapshot_t* leveldb_create_snapshot(leveldb_t* db);
 


### PR DESCRIPTION
This commit adds support to open/close/create_iter on leveldb
table file directly.  This change is wanted when trying to use
the C api to access the 'index' file generated by the
https://github.com/google/stenographer application.

The implementation simply mimics the db/dumpfile.cc code.