### PR TITLE
Fix WindowsLogger crash

### DIFF
--- a/util/windows_logger.h
+++ b/util/windows_logger.h
@@ -58,7 +58,7 @@ class WindowsLogger final : public Logger {
       // Print the header into the buffer.
       // TODO(costan): Sync this logger with another logger.
       int buffer_offset = snprintf(
-          buffer, buffer_size, "%04d/%02d/%02d-%02d:%02d:%02d.%06d %s ",
+          buffer, buffer_size, "%04d/%02d/%02d-%02d:%02d:%02d.%06d %llu ",
           now_components.wYear, now_components.wMonth, now_components.wDay,
           now_components.wHour, now_components.wMinute, now_components.wSecond,
           static_cast<int>(now_components.wMilliseconds * 1000),
@@ -106,7 +106,9 @@ class WindowsLogger final : public Logger {
       }
 
       assert(buffer_offset <= buffer_size);
-      ::WriteFile(handle_, buffer, buffer_offset, nullptr, nullptr);
+
+      DWORD written = 0;
+      ::WriteFile(handle_, buffer, buffer_offset, &written, nullptr);
 
       if (iteration != 0) {
         delete[] buffer;


### PR DESCRIPTION
Windows port always crash since code is broken.

![image](https://user-images.githubusercontent.com/10111/53799609-160eab00-3f7e-11e9-99ac-4729609fe844.png)


* format string of std::stoull should be `%llu`% not `%s`.
* the 4th argument of WriteFile should not be nullptr if the call of WriteFile is not asynchronous.

```
[36mRunning tests...[0m

Test project C:/dev/leveldb/build
      Start  1: c_test
 1/29 Test  #1: c_test ...........................   Passed    0.58 sec
      Start  2: fault_injection_test
 2/29 Test  #2: fault_injection_test .............   Passed    2.33 sec
      Start  3: issue178_test
 3/29 Test  #3: issue178_test ....................   Passed   15.09 sec
      Start  4: issue200_test
 4/29 Test  #4: issue200_test ....................   Passed    0.14 sec
      Start  5: env_test
 5/29 Test  #5: env_test .........................   Passed    0.53 sec
      Start  6: status_test
 6/29 Test  #6: status_test ......................   Passed    0.09 sec
      Start  7: no_destructor_test
 7/29 Test  #7: no_destructor_test ...............   Passed    0.06 sec
      Start  8: autocompact_test
 8/29 Test  #8: autocompact_test .................   Passed   19.35 sec
      Start  9: corruption_test
 9/29 Test  #9: corruption_test ..................***Failed    0.27 sec
      Start 10: db_test
10/29 Test #10: db_test ..........................   Passed   73.76 sec
      Start 11: dbformat_test
11/29 Test #11: dbformat_test ....................   Passed    0.05 sec
      Start 12: filename_test
12/29 Test #12: filename_test ....................   Passed    0.05 sec
      Start 13: log_test
13/29 Test #13: log_test .........................   Passed    0.24 sec
      Start 14: recovery_test
14/29 Test #14: recovery_test ....................   Passed    0.49 sec
      Start 15: skiplist_test
15/29 Test #15: skiplist_test ....................   Passed    2.19 sec
      Start 16: version_edit_test
16/29 Test #16: version_edit_test ................   Passed    0.05 sec
      Start 17: version_set_test
17/29 Test #17: version_set_test .................   Passed    0.06 sec
      Start 18: write_batch_test
18/29 Test #18: write_batch_test .................   Passed    0.05 sec
      Start 19: memenv_test
19/29 Test #19: memenv_test ......................   Passed    0.07 sec
      Start 20: filter_block_test
20/29 Test #20: filter_block_test ................   Passed    0.05 sec
      Start 21: table_test
21/29 Test #21: table_test .......................   Passed    7.27 sec
      Start 22: arena_test
22/29 Test #22: arena_test .......................   Passed    0.94 sec
      Start 23: bloom_test
23/29 Test #23: bloom_test .......................   Passed    0.13 sec
      Start 24: cache_test
24/29 Test #24: cache_test .......................   Passed    0.06 sec
      Start 25: coding_test
25/29 Test #25: coding_test ......................   Passed    0.10 sec
      Start 26: crc32c_test
26/29 Test #26: crc32c_test ......................   Passed    0.05 sec
      Start 27: hash_test
27/29 Test #27: hash_test ........................   Passed    0.05 sec
      Start 28: logging_test
28/29 Test #28: logging_test .....................   Passed    0.05 sec
      Start 29: env_windows_test
29/29 Test #29: env_windows_test .................   Passed    0.05 sec

97% tests passed, 1 tests failed out of 29

Total Test time (real) = 124.25 sec

The following tests FAILED:
	  9 - corruption_test (Failed)
Errors while running CTest
mingw32-make: *** [Makefile:130: test] Error 8

```

corruption_test is still failing. But this should be another cause.