### PR TITLE
Use Version::ForEachOverlapping to implement Version::Get()

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -281,7 +281,6 @@ static bool NewestFirst(FileMetaData* a, FileMetaData* b) {
 
 void Version::ForEachOverlapping(Slice user_key, Slice internal_key, void* arg,
                                  bool (*func)(void*, int, FileMetaData*)) {
-  // TODO(sanjay): Change Version::Get() to use this function.
   const Comparator* ucmp = vset_->icmp_.user_comparator();
 
   // Search level-0 in order from newest to oldest.

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -328,7 +328,7 @@ Status Version::Get(const ReadOptions& options, const LookupKey& k,
   Slice ikey = k.internal_key();
   Slice user_key = k.user_key();
   const Comparator* ucmp = vset_->icmp_.user_comparator();
-  
+
   stats->seek_file = nullptr;
   stats->seek_file_level = -1;
 
@@ -339,16 +339,17 @@ Status Version::Get(const ReadOptions& options, const LookupKey& k,
     Slice user_key;
     const Comparator* ucmp;
     std::string* value;
-    FileMetaData *last_file_read;
+    FileMetaData* last_file_read;
     int last_file_level;
 
-    VersionSet *vset;
+    VersionSet* vset;
     Status s;
 
     static bool Match(void* arg, int level, FileMetaData* f) {
       State* state = reinterpret_cast<State*>(arg);
 
-      if (state->last_file_read != nullptr && state->stats->seek_file == nullptr) {
+      if (state->last_file_read != nullptr &&
+          state->stats->seek_file == nullptr) {
         // We have had more than one seek for this read.  Charge the 1st file.
         state->stats->seek_file = state->last_file_read;
         state->stats->seek_file_level = state->last_file_level;
@@ -371,7 +372,7 @@ Status Version::Get(const ReadOptions& options, const LookupKey& k,
       }
       switch (saver.state) {
         case kNotFound:
-          return true; // Keep saerching in other files
+          return true;  // Keep saerching in other files
         case kFound:
           state->s = s;
           return false;
@@ -395,7 +396,7 @@ Status Version::Get(const ReadOptions& options, const LookupKey& k,
   state.ucmp = ucmp;
   state.value = value;
   state.vset = vset_;
-  
+
   ForEachOverlapping(user_key, ikey, &state, &State::Match);
 
   return state.s;


### PR DESCRIPTION
This code has been tested with existing tests and no new tests are written because it justs implements  Version:: Get() with Version:: ForEachOverlapping() which has been fully tested.