### PR TITLE
change data type for num_entries from int64_t to uint64_t

### DIFF
--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -43,7 +43,7 @@ struct TableBuilder::Rep {
   BlockBuilder data_block;
   BlockBuilder index_block;
   std::string last_key;
-  int64_t num_entries;
+  uint64_t num_entries;
   bool closed;  // Either Finish() or Abandon() has been called.
   FilterBlockBuilder* filter_block;
 


### PR DESCRIPTION
Change the data type for `num_entries` in `table_builder.cc` from `int64_t` to `uint64_t`

Ran `make test` under UNIX environment, can pass all tests.