### PR TITLE
add disableWAL option

### DIFF
--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -180,6 +180,10 @@ struct LEVELDB_EXPORT WriteOptions {
   // with sync==true has similar crash semantics to a "write()"
   // system call followed by "fsync()".
   bool sync = false;
+
+  // If true, writes will not first go to the write ahead log,
+  // and the write may got lost after a crash.
+  bool disableWAL = false;
 };
 
 }  // namespace leveldb


### PR DESCRIPTION
When WAL is disabled, performance of 'fillseq' is improved a lot.

When WAL is disabled, performance of 'fillseq' is improved a lot.

This option is helpful when doing bulk load. And in-memory data will
be flushed to disk if CompactRange(nullptr, nullptr) is called at the
end of load.

```
$ time ./db_bench --benchmarks=fillseq --db=/tmp/db --disable_wal=0
LevelDB:    version 1.22
Date:       Sat Jul  6 23:51:41 2019
CPU:        16 * Intel(R) Core(TM)2 Duo CPU     T7700  @ 2.40GHz
CPUCache:   4096 KB
Keys:       16 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
RawSize:    110.6 MB (estimated)
FileSize:   62.9 MB (estimated)
------------------------------------------------
fillseq      :       4.783 micros/op;   23.1 MB/s

real    0m4.798s
user    0m3.708s
sys     0m2.005s

$ time ./db_bench --benchmarks=fillseq --db=/tmp/db --disable_wal=1
LevelDB:    version 1.22
Date:       Sat Jul  6 23:52:02 2019
CPU:        16 * Intel(R) Core(TM)2 Duo CPU     T7700  @ 2.40GHz
CPUCache:   4096 KB
Keys:       16 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
RawSize:    110.6 MB (estimated)
FileSize:   62.9 MB (estimated)
------------------------------------------------
fillseq      :       1.227 micros/op;   90.2 MB/s

real    0m1.253s
user    0m1.657s
sys     0m0.233s
```

Signed-off-by: Kyle Zhang <kyle@smartx.com>