### PR TITLE
avoid costly string operations in Block::Iter::ParseNextKey

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -240,8 +240,8 @@ class Block::Iter : public Iterator {
       CorruptionError();
       return false;
     } else {
-      key_.resize(shared);
-      key_.append(p, non_shared);
+      key_.resize(shared + non_shared);
+      memcpy(&key_[shared], p, non_shared);
       value_ = Slice(p + non_shared, value_length);
       while (restart_index_ + 1 < num_restarts_ &&
              GetRestartPoint(restart_index_ + 1) < current_) {


### PR DESCRIPTION
In current implementation, key_ is resized to 'shared' and then append
with a 'non_shared' length string. These will cause key_ shrink and
then expand.

This patch fixed the problem by resizing key_ to 'shared+nonshared'
directly and then do memcpy.

Without this patch

./db_bench --benchmarks=readseq --num=$((1<<20)) --db=/tmp/db --use_existing_db=1
LevelDB:    version 1.22
Date:       Wed Sep 11 18:45:56 2019
CPU:        24 * Intel(R) Xeon(R) CPU E5-2620 v2 @ 2.10GHz
CPUCache:   15360 KB
Keys:       16 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1048576
RawSize:    116.0 MB (estimated)
FileSize:   66.0 MB (estimated)
------------------------------------------------
readseq      :       0.279 micros/op;  396.7 MB/s

With this patch

./db_bench --benchmarks=readseq --num=$((1<<20)) --db=/tmp/db --use_existing_db=1
LevelDB:    version 1.22
Date:       Wed Sep 11 18:45:56 2019
CPU:        24 * Intel(R) Xeon(R) CPU E5-2620 v2 @ 2.10GHz
CPUCache:   15360 KB
Keys:       16 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1048576
RawSize:    116.0 MB (estimated)
FileSize:   66.0 MB (estimated)
------------------------------------------------
readseq      :       0.265 micros/op;  416.8 MB/s

Signed-off-by: Kyle Zhang <kyle@smartx.com>