### PR TITLE
Fix dismatch of code and comment

### DIFF
--- a/db/version_set.h
+++ b/db/version_set.h
@@ -59,9 +59,6 @@ bool SomeFileOverlapsRange(const InternalKeyComparator& icmp,
 
 class Version {
  public:
-  // Lookup the value for key.  If found, store it in *val and
-  // return OK.  Else return a non-OK status.  Fills *stats.
-  // REQUIRES: lock is not held
   struct GetStats {
     FileMetaData* seek_file;
     int seek_file_level;
@@ -72,6 +69,9 @@ class Version {
   // REQUIRES: This version has been saved (see VersionSet::SaveTo)
   void AddIterators(const ReadOptions&, std::vector<Iterator*>* iters);
 
+  // Lookup the value for key.  If found, store it in *val and
+  // return OK.  Else return a non-OK status.  Fills *stats.
+  // REQUIRES: lock is not held
   Status Get(const ReadOptions&, const LookupKey& key, std::string* val,
              GetStats* stats);
 


### PR DESCRIPTION
The code comment didn't match the code:
https://github.com/google/leveldb/blob/21304d41f77990b8edabbdab33b222bd5ceb5f18/db/version_set.h#L62-L75

I fixed it.