### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ Authors: Sanjay Ghemawat (sanjay@google.com) and Jeff Dean (jeff@google.com)
   * Only a single process (possibly multi-threaded) can access a particular database at a time.
   * There is no client-server support builtin to the library.  An application that needs such support will have to wrap their own server around the library.
 
+# Package Managers
+
+You can download and install LevelDB using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install leveldb
+
+The LevelDB port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 # Building
 
 This project supports [CMake](https://cmake.org/) out of the box.


### PR DESCRIPTION
LevelDB is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for LevelDB and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build LevelDB, ready to be included in their projects. 

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/leveldb/portfile.cmake). We try to keep the library maintained as close as possible to the original library.