### PR TITLE
Fix for MSVC warning C4715

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -373,6 +373,8 @@ Status Version::Get(const ReadOptions& options, const LookupKey& k,
           state->found = true;
           return false;
       }
+      
+      return false;
     }
   };
 


### PR DESCRIPTION
Makes MSVC happy by returning on all control paths.

Even though the `switch (state->saver.state)` is exhaustive, MSVC complains
about some code paths not leading to a return statement when building with
all warnings enabled.

```
...\leveldb\db\version_set.cc(376) : warning C4715: '`leveldb::Version::Get'::`2'::State::Match': not all control paths return a value
```