### PR TITLE
Fix typo in comment of LRUHandle

### DIFF
--- a/util/cache.cc
+++ b/util/cache.cc
@@ -53,7 +53,7 @@ struct LRUHandle {
   char key_data[1];  // Beginning of key
 
   Slice key() const {
-    // next_ is only equal to this if the LRU handle is the list head of an
+    // next is only equal to this if the LRU handle is the list head of an
     // empty list. List heads never have meaningful keys.
     assert(next != this);
 


### PR DESCRIPTION
LRUHandle has no member "next_", fix it to "next" instead.