### PR TITLE
Fix issue #718

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -7,7 +7,6 @@
 #include <atomic>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "db/db_impl.h"
 #include "db/filename.h"
 #include "db/version_set.h"
@@ -22,6 +21,7 @@
 #include "util/logging.h"
 #include "util/mutexlock.h"
 #include "util/testutil.h"
+#include "gtest/gtest.h"
 
 namespace leveldb {
 
@@ -572,6 +572,9 @@ TEST_F(DBTest, ReadWrite) {
     ASSERT_LEVELDB_OK(Put("foo", "v3"));
     ASSERT_EQ("v3", Get("foo"));
     ASSERT_EQ("v2", Get("bar"));
+    size_t sz = 1ull << 32;
+    ASSERT_LEVELDB_OK(Put("goo", std::string(sz, 'h')));
+    ASSERT_EQ(sz, Get("goo").size());
   } while (ChangeOptions());
 }
 

--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -16,7 +16,7 @@
 // An entry for a particular key-value pair has the form:
 //     shared_bytes: varint32
 //     unshared_bytes: varint32
-//     value_length: varint32
+//     value_length: varint64
 //     key_delta: char[unshared_bytes]
 //     value: char[value_length]
 // shared_bytes == 0 for restart points.
@@ -92,7 +92,7 @@ void BlockBuilder::Add(const Slice& key, const Slice& value) {
   // Add "<shared><non_shared><value_size>" to buffer_
   PutVarint32(&buffer_, shared);
   PutVarint32(&buffer_, non_shared);
-  PutVarint32(&buffer_, value.size());
+  PutVarint64(&buffer_, value.size());
 
   // Add string delta to buffer_ followed by value
   buffer_.append(key.data() + shared, non_shared);

--- a/util/coding.cc
+++ b/util/coding.cc
@@ -70,7 +70,7 @@ void PutVarint64(std::string* dst, uint64_t v) {
 }
 
 void PutLengthPrefixedSlice(std::string* dst, const Slice& value) {
-  PutVarint32(dst, value.size());
+  PutVarint64(dst, value.size());
   dst->append(value.data(), value.size());
 }
 
@@ -144,8 +144,8 @@ bool GetVarint64(Slice* input, uint64_t* value) {
 
 const char* GetLengthPrefixedSlice(const char* p, const char* limit,
                                    Slice* result) {
-  uint32_t len;
-  p = GetVarint32Ptr(p, limit, &len);
+  uint64_t len;
+  p = GetVarint64Ptr(p, limit, &len);
   if (p == nullptr) return nullptr;
   if (p + len > limit) return nullptr;
   *result = Slice(p, len);
@@ -153,8 +153,8 @@ const char* GetLengthPrefixedSlice(const char* p, const char* limit,
 }
 
 bool GetLengthPrefixedSlice(Slice* input, Slice* result) {
-  uint32_t len;
-  if (GetVarint32(input, &len) && input->size() >= len) {
+  uint64_t len;
+  if (GetVarint64(input, &len) && input->size() >= len) {
     *result = Slice(input->data(), len);
     input->remove_prefix(len);
     return true;


### PR DESCRIPTION
The issue occurs because the default type of value's size is `uint32_t`,
 which is not appropriate for size lager than `1ull << 32`.
 I fix this issue by using `uint64_t` to hold the value's size, and store
 it as `Varint64`.
 I have added a test to db_test.cc, the result is ok.

The test result:
`
➜  build git:(fix-issue#718) ✗ make test
Running tests...
Test project /home/lfs/dd/int/leveldb/build
      Start  1: c_test
 1/30 Test  #1: c_test ...........................   Passed    0.43 sec
      Start  2: fault_injection_test
 2/30 Test  #2: fault_injection_test .............   Passed    1.64 sec
      Start  3: issue178_test
 3/30 Test  #3: issue178_test ....................   Passed    4.02 sec
      Start  4: issue200_test
 4/30 Test  #4: issue200_test ....................   Passed    0.03 sec
      Start  5: issue320_test
 5/30 Test  #5: issue320_test ....................   Passed   12.52 sec
      Start  6: env_test
 6/30 Test  #6: env_test .........................   Passed    0.15 sec
      Start  7: status_test
 7/30 Test  #7: status_test ......................   Passed    0.00 sec
      Start  8: no_destructor_test
 8/30 Test  #8: no_destructor_test ...............   Passed    0.00 sec
      Start  9: autocompact_test
 9/30 Test  #9: autocompact_test .................   Passed   22.79 sec
      Start 10: corruption_test
10/30 Test #10: corruption_test ..................   Passed    0.40 sec
      Start 11: db_test
11/30 Test #11: db_test ..........................   Passed  192.43 sec
      Start 12: dbformat_test
12/30 Test #12: dbformat_test ....................   Passed    0.05 sec
      Start 13: filename_test
13/30 Test #13: filename_test ....................   Passed    0.05 sec
      Start 14: log_test
14/30 Test #14: log_test .........................   Passed    0.08 sec
      Start 15: recovery_test
15/30 Test #15: recovery_test ....................   Passed    0.20 sec
      Start 16: skiplist_test
16/30 Test #16: skiplist_test ....................   Passed    0.48 sec
      Start 17: version_edit_test
17/30 Test #17: version_edit_test ................   Passed    0.02 sec
      Start 18: version_set_test
18/30 Test #18: version_set_test .................   Passed    0.01 sec
      Start 19: write_batch_test
19/30 Test #19: write_batch_test .................   Passed    0.02 sec
      Start 20: memenv_test
20/30 Test #20: memenv_test ......................   Passed    0.04 sec
      Start 21: filter_block_test
21/30 Test #21: filter_block_test ................   Passed    0.02 sec
      Start 22: table_test
22/30 Test #22: table_test .......................   Passed    4.89 sec
      Start 23: arena_test
23/30 Test #23: arena_test .......................   Passed    0.07 sec
      Start 24: bloom_test
24/30 Test #24: bloom_test .......................   Passed    0.03 sec
      Start 25: cache_test
25/30 Test #25: cache_test .......................   Passed    0.03 sec
      Start 26: coding_test
26/30 Test #26: coding_test ......................   Passed    0.02 sec
      Start 27: crc32c_test
27/30 Test #27: crc32c_test ......................   Passed    0.02 sec
      Start 28: hash_test
28/30 Test #28: hash_test ........................   Passed    0.02 sec
      Start 29: logging_test
29/30 Test #29: logging_test .....................   Passed    0.01 sec
      Start 30: env_posix_test
30/30 Test #30: env_posix_test ...................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 30

Total Test time (real) = 240.62 sec
`
