### PR TITLE
Fix issue#718

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ if(LEVELDB_BUILD_TESTS)
   leveldb_test("issues/issue178_test.cc")
   leveldb_test("issues/issue200_test.cc")
   leveldb_test("issues/issue320_test.cc")
+  leveldb_test("issues/issue718_test.cc")
 
   leveldb_test("util/env_test.cc")
   leveldb_test("util/status_test.cc")

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -572,9 +572,6 @@ TEST_F(DBTest, ReadWrite) {
     ASSERT_LEVELDB_OK(Put("foo", "v3"));
     ASSERT_EQ("v3", Get("foo"));
     ASSERT_EQ("v2", Get("bar"));
-    size_t sz = 1ull << 32;
-    ASSERT_LEVELDB_OK(Put("goo", std::string(sz, 'h')));
-    ASSERT_EQ(sz, Get("goo").size());
   } while (ChangeOptions());
 }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -7,7 +7,6 @@
 #include <atomic>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "db/db_impl.h"
 #include "db/filename.h"
 #include "db/version_set.h"
@@ -22,6 +21,7 @@
 #include "util/logging.h"
 #include "util/mutexlock.h"
 #include "util/testutil.h"
+#include "gtest/gtest.h"
 
 namespace leveldb {
 
@@ -572,6 +572,9 @@ TEST_F(DBTest, ReadWrite) {
     ASSERT_LEVELDB_OK(Put("foo", "v3"));
     ASSERT_EQ("v3", Get("foo"));
     ASSERT_EQ("v2", Get("bar"));
+    size_t sz = 1ull << 32;
+    ASSERT_LEVELDB_OK(Put("goo", std::string(sz, 'h')));
+    ASSERT_EQ(sz, Get("goo").size());
   } while (ChangeOptions());
 }
 

--- a/issues/issue718_test.cc
+++ b/issues/issue718_test.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// Test for issue 718: leveldb crashes when the values's size is bigger
+// than 1ull << 32.
+
+#include <cstdlib>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "leveldb/db.h"
+#include "util/testutil.h"
+
+namespace {
+
+TEST(Issue718, Test) {
+  std::srand(std::time(0));
+  leveldb::DB* db;
+  leveldb::Options options;
+  options.create_if_missing = true;
+  options.compression = leveldb::kNoCompression;
+  std::string dbpath = testing::TempDir() + "leveldb_issue718_test";
+  ASSERT_LEVELDB_OK(leveldb::DB::Open(options, dbpath, &db));
+
+  size_t val_size = (1ull << 32) + (rand() % 1024);
+  char c = static_cast<char>(rand() % 256);
+  std::string key("test_issue718");
+  std::string value(val_size, c);
+  std::string get_value;
+  ASSERT_LEVELDB_OK(db->Put(leveldb::WriteOptions(), key, value));
+  ASSERT_LEVELDB_OK(db->Get(leveldb::ReadOptions(), key, &get_value));
+  ASSERT_EQ(value, get_value);
+
+  delete db;
+
+  ASSERT_LEVELDB_OK(leveldb::DB::Open(options, dbpath, &db));
+  get_value.clear();
+  ASSERT_LEVELDB_OK(db->Get(leveldb::ReadOptions(), key, &get_value));
+  ASSERT_EQ(value, get_value);
+
+  DestroyDB(dbpath, options);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/table/block.cc
+++ b/table/block.cc
@@ -29,12 +29,13 @@ Block::Block(const BlockContents& contents)
   if (size_ < sizeof(uint32_t)) {
     size_ = 0;  // Error marker
   } else {
-    size_t max_restarts_allowed = (size_ - sizeof(uint32_t)) / sizeof(uint32_t);
+    size_t max_restarts_allowed = (size_ - sizeof(uint32_t)) / sizeof(uint64_t);
     if (NumRestarts() > max_restarts_allowed) {
       // The size is too small for NumRestarts()
       size_ = 0;
     } else {
-      restart_offset_ = size_ - (1 + NumRestarts()) * sizeof(uint32_t);
+      restart_offset_ = size_ - NumRestarts() * sizeof(uint64_t)
+      - sizeof(uint32_t);
     }
   }
 }
@@ -78,11 +79,11 @@ class Block::Iter : public Iterator {
  private:
   const Comparator* const comparator_;
   const char* const data_;       // underlying block contents
-  uint32_t const restarts_;      // Offset of restart array (list of fixed32)
-  uint32_t const num_restarts_;  // Number of uint32_t entries in restart array
+  uint64_t const restarts_;      // Offset of restart array (list of fixed64)
+  uint32_t const num_restarts_;  // Number of uint64_t entries in restart array
 
   // current_ is offset in data_ of current entry.  >= restarts_ if !Valid
-  uint32_t current_;
+  uint64_t current_;
   uint32_t restart_index_;  // Index of restart block in which current_ falls
   std::string key_;
   Slice value_;
@@ -93,13 +94,13 @@ class Block::Iter : public Iterator {
   }
 
   // Return the offset in data_ just past the end of the current entry.
-  inline uint32_t NextEntryOffset() const {
+  inline uint64_t NextEntryOffset() const {
     return (value_.data() + value_.size()) - data_;
   }
 
-  uint32_t GetRestartPoint(uint32_t index) {
+  uint64_t GetRestartPoint(uint32_t index) {
     assert(index < num_restarts_);
-    return DecodeFixed32(data_ + restarts_ + index * sizeof(uint32_t));
+    return DecodeFixed64(data_ + restarts_ + index * sizeof(uint64_t));
   }
 
   void SeekToRestartPoint(uint32_t index) {
@@ -108,12 +109,12 @@ class Block::Iter : public Iterator {
     // current_ will be fixed by ParseNextKey();
 
     // ParseNextKey() starts at the end of value_, so set value_ accordingly
-    uint32_t offset = GetRestartPoint(index);
+    uint64_t offset = GetRestartPoint(index);
     value_ = Slice(data_ + offset, 0);
   }
 
  public:
-  Iter(const Comparator* comparator, const char* data, uint32_t restarts,
+  Iter(const Comparator* comparator, const char* data, uint64_t restarts,
        uint32_t num_restarts)
       : comparator_(comparator),
         data_(data),
@@ -144,7 +145,7 @@ class Block::Iter : public Iterator {
     assert(Valid());
 
     // Scan backwards to a restart point before current_
-    const uint32_t original = current_;
+    const uint64_t original = current_;
     while (GetRestartPoint(restart_index_) >= original) {
       if (restart_index_ == 0) {
         // No more entries
@@ -168,7 +169,7 @@ class Block::Iter : public Iterator {
     uint32_t right = num_restarts_ - 1;
     while (left < right) {
       uint32_t mid = (left + right + 1) / 2;
-      uint32_t region_offset = GetRestartPoint(mid);
+      uint64_t region_offset = GetRestartPoint(mid);
       uint32_t shared, non_shared;
       uint64_t value_length;
       const char* key_ptr =

--- a/table/block.h
+++ b/table/block.h
@@ -35,7 +35,7 @@ class Block {
 
   const char* data_;
   size_t size_;
-  uint32_t restart_offset_;  // Offset in data_ of restart array
+  uint64_t restart_offset_;  // Offset in data_ of restart array
   bool owned_;               // Block owns data_[]
 };
 

--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -16,7 +16,7 @@
 // An entry for a particular key-value pair has the form:
 //     shared_bytes: varint32
 //     unshared_bytes: varint32
-//     value_length: varint32
+//     value_length: varint64
 //     key_delta: char[unshared_bytes]
 //     value: char[value_length]
 // shared_bytes == 0 for restart points.
@@ -92,7 +92,7 @@ void BlockBuilder::Add(const Slice& key, const Slice& value) {
   // Add "<shared><non_shared><value_size>" to buffer_
   PutVarint32(&buffer_, shared);
   PutVarint32(&buffer_, non_shared);
-  PutVarint32(&buffer_, value.size());
+  PutVarint64(&buffer_, value.size());
 
   // Add string delta to buffer_ followed by value
   buffer_.append(key.data() + shared, non_shared);

--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -22,7 +22,7 @@
 // shared_bytes == 0 for restart points.
 //
 // The trailer of the block has the form:
-//     restarts: uint32[num_restarts]
+//     restarts: uint64[num_restarts]
 //     num_restarts: uint32
 // restarts[i] contains the offset within the block of the ith restart point.
 
@@ -55,14 +55,14 @@ void BlockBuilder::Reset() {
 
 size_t BlockBuilder::CurrentSizeEstimate() const {
   return (buffer_.size() +                       // Raw data buffer
-          restarts_.size() * sizeof(uint32_t) +  // Restart array
+          restarts_.size() * sizeof(uint64_t) +  // Restart array
           sizeof(uint32_t));                     // Restart array length
 }
 
 Slice BlockBuilder::Finish() {
   // Append restart array
   for (size_t i = 0; i < restarts_.size(); i++) {
-    PutFixed32(&buffer_, restarts_[i]);
+    PutFixed64(&buffer_, restarts_[i]);
   }
   PutFixed32(&buffer_, restarts_.size());
   finished_ = true;

--- a/table/block_builder.h
+++ b/table/block_builder.h
@@ -44,7 +44,7 @@ class BlockBuilder {
  private:
   const Options* options_;
   std::string buffer_;              // Destination buffer
-  std::vector<uint32_t> restarts_;  // Restart points
+  std::vector<uint64_t> restarts_;  // Restart points
   int counter_;                     // Number of entries emitted since restart
   bool finished_;                   // Has Finish() been called?
   std::string last_key_;

--- a/util/coding.cc
+++ b/util/coding.cc
@@ -70,7 +70,7 @@ void PutVarint64(std::string* dst, uint64_t v) {
 }
 
 void PutLengthPrefixedSlice(std::string* dst, const Slice& value) {
-  PutVarint32(dst, value.size());
+  PutVarint64(dst, value.size());
   dst->append(value.data(), value.size());
 }
 
@@ -144,8 +144,8 @@ bool GetVarint64(Slice* input, uint64_t* value) {
 
 const char* GetLengthPrefixedSlice(const char* p, const char* limit,
                                    Slice* result) {
-  uint32_t len;
-  p = GetVarint32Ptr(p, limit, &len);
+  uint64_t len;
+  p = GetVarint64Ptr(p, limit, &len);
   if (p == nullptr) return nullptr;
   if (p + len > limit) return nullptr;
   *result = Slice(p, len);
@@ -153,8 +153,8 @@ const char* GetLengthPrefixedSlice(const char* p, const char* limit,
 }
 
 bool GetLengthPrefixedSlice(Slice* input, Slice* result) {
-  uint32_t len;
-  if (GetVarint32(input, &len) && input->size() >= len) {
+  uint64_t len;
+  if (GetVarint64(input, &len) && input->size() >= len) {
     *result = Slice(input->data(), len);
     input->remove_prefix(len);
     return true;


### PR DESCRIPTION
The issue is because leveldb doesnot support value size bigger than `1ull << 32`.
A test file is added, and snappy commpression is not used in the test because it
seems not support data whose size is lagger than `uint32_t` can hold. Here is the
corespoding code.
https://github.com/google/leveldb/blob/c784d63b931d07895833fb80185b10d44ad63cce/table/format.cc#L117-L125
https://github.com/google/snappy/blob/62363d9a797e4c6607193cb14000cd3a7705c185/snappy.cc#L434-L443