### PR TITLE
Fix issue #718

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ if(LEVELDB_BUILD_TESTS)
   leveldb_test("issues/issue178_test.cc")
   leveldb_test("issues/issue200_test.cc")
   leveldb_test("issues/issue320_test.cc")
+  leveldb_test("issues/issue718_test.cc")
 
   leveldb_test("util/env_test.cc")
   leveldb_test("util/status_test.cc")

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -7,7 +7,6 @@
 #include <atomic>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "db/db_impl.h"
 #include "db/filename.h"
 #include "db/version_set.h"
@@ -22,6 +21,7 @@
 #include "util/logging.h"
 #include "util/mutexlock.h"
 #include "util/testutil.h"
+#include "gtest/gtest.h"
 
 namespace leveldb {
 

--- a/issues/issue718_test.cc
+++ b/issues/issue718_test.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// Test for issue 718: leveldb crashes when the values's size is bigger
+// than 1ull << 32.
+
+#include <cstdlib>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "leveldb/db.h"
+#include "util/testutil.h"
+
+namespace {
+
+TEST(Issue718, Test) {
+  std::srand(std::time(0));
+  leveldb::DB* db;
+  leveldb::Options options;
+  options.create_if_missing = true;
+  options.compression = leveldb::kNoCompression;
+  std::string dbpath = testing::TempDir() + "leveldb_issue718_test";
+  ASSERT_LEVELDB_OK(leveldb::DB::Open(options, dbpath, &db));
+
+  size_t val_size = (1ull << 32) + (rand() % 1024);
+  char c = static_cast<char>(rand() % 256);
+  std::string key("test_issue718");
+  std::string value(val_size, c);
+  std::string get_value;
+  ASSERT_LEVELDB_OK(db->Put(leveldb::WriteOptions(), key, value));
+  ASSERT_LEVELDB_OK(db->Get(leveldb::ReadOptions(), key, &get_value));
+  ASSERT_EQ(value, get_value);
+
+  delete db;
+
+  ASSERT_LEVELDB_OK(leveldb::DB::Open(options, dbpath, &db));
+  get_value.clear();
+  ASSERT_LEVELDB_OK(db->Get(leveldb::ReadOptions(), key, &get_value));
+  ASSERT_EQ(value, get_value);
+
+  DestroyDB(dbpath, options);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/table/block.h
+++ b/table/block.h
@@ -35,7 +35,7 @@ class Block {
 
   const char* data_;
   size_t size_;
-  uint32_t restart_offset_;  // Offset in data_ of restart array
+  uint64_t restart_offset_;  // Offset in data_ of restart array
   bool owned_;               // Block owns data_[]
 };
 

--- a/table/block_builder.h
+++ b/table/block_builder.h
@@ -44,7 +44,7 @@ class BlockBuilder {
  private:
   const Options* options_;
   std::string buffer_;              // Destination buffer
-  std::vector<uint32_t> restarts_;  // Restart points
+  std::vector<uint64_t> restarts_;  // Restart points
   int counter_;                     // Number of entries emitted since restart
   bool finished_;                   // Has Finish() been called?
   std::string last_key_;

--- a/util/coding.cc
+++ b/util/coding.cc
@@ -70,7 +70,7 @@ void PutVarint64(std::string* dst, uint64_t v) {
 }
 
 void PutLengthPrefixedSlice(std::string* dst, const Slice& value) {
-  PutVarint32(dst, value.size());
+  PutVarint64(dst, value.size());
   dst->append(value.data(), value.size());
 }
 
@@ -144,8 +144,8 @@ bool GetVarint64(Slice* input, uint64_t* value) {
 
 const char* GetLengthPrefixedSlice(const char* p, const char* limit,
                                    Slice* result) {
-  uint32_t len;
-  p = GetVarint32Ptr(p, limit, &len);
+  uint64_t len;
+  p = GetVarint64Ptr(p, limit, &len);
   if (p == nullptr) return nullptr;
   if (p + len > limit) return nullptr;
   *result = Slice(p, len);
@@ -153,8 +153,8 @@ const char* GetLengthPrefixedSlice(const char* p, const char* limit,
 }
 
 bool GetLengthPrefixedSlice(Slice* input, Slice* result) {
-  uint32_t len;
-  if (GetVarint32(input, &len) && input->size() >= len) {
+  uint64_t len;
+  if (GetVarint64(input, &len) && input->size() >= len) {
     *result = Slice(input->data(), len);
     input->remove_prefix(len);
     return true;


### PR DESCRIPTION
The issue occurs because leveldb does not support values size bigger than
`1ull << 32`. The snappy compression library does not souport data larger
than `1ull << 32` as well, so my new test use the option `kNoCompression`.