### PR TITLE
Enable -Werror=conditional-uninitialized if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,13 @@ if(BUILD_SHARED_LIBS)
   )
 endif(BUILD_SHARED_LIBS)
 
+check_cxx_compiler_flag(-Werror=conditional-uninitialized HAVE_CONDITIONAL_UNINITIALIZED)
+if(HAVE_CONDITIONAL_UNINITIALIZED)
+  target_compile_options(leveldb
+    PUBLIC
+      -Werror=conditional-uninitialized)
+endif(HAVE_CONDITIONAL_UNINITIALIZED)
+
 if(HAVE_CLANG_THREAD_SAFETY)
   target_compile_options(leveldb
     PUBLIC

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -157,7 +157,7 @@ class CorruptionTest : public testing::Test {
 
   int Property(const std::string& name) {
     std::string property;
-    int result;
+    int result = -1;
     if (db_->GetProperty(name, &property) &&
         sscanf(property.c_str(), "%d", &result) == 1) {
       return result;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -994,7 +994,7 @@ bool VersionSet::ReuseManifest(const std::string& dscname,
   }
   FileType manifest_type;
   uint64_t manifest_number;
-  uint64_t manifest_size;
+  uint64_t manifest_size = 0;
   if (!ParseFileName(dscbase, &manifest_number, &manifest_type) ||
       manifest_type != kDescriptorFile ||
       !env_->GetFileSize(dscname, &manifest_size).ok() ||


### PR DESCRIPTION
And fix two trivial local violations - initialized to the empty or
failing value.

Note, in the current code these are false positives as the called
functions do set the value in all cases, but these initializations
remove the reliance on that external property, and enable
automatic detections of future violations.

Motivated by a desire to enable this warning in a project
that builds leveldb as a dependency.