### PR TITLE
Implement #234.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ option(LEVELDB_BUILD_TESTS "Build LevelDB's unit tests" ON)
 option(LEVELDB_BUILD_BENCHMARKS "Build LevelDB's benchmarks" ON)
 option(LEVELDB_INSTALL "Install LevelDB's header and library" ON)
 
+option(LEVELDB_DISABLE_CRC32C "Disable crc32c" OFF)
+option(LEVELDB_DISABLE_SNAPPY "Disable snappy" OFF)
+option(LEVELDB_DISABLE_TCMALLOC "Disable tcmalloc" OFF)
+
 include(TestBigEndian)
 test_big_endian(LEVELDB_IS_BIG_ENDIAN)
 
@@ -41,9 +45,15 @@ include(CheckIncludeFile)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 
 include(CheckLibraryExists)
-check_library_exists(crc32c crc32c_value "" HAVE_CRC32C)
-check_library_exists(snappy snappy_compress "" HAVE_SNAPPY)
-check_library_exists(tcmalloc malloc "" HAVE_TCMALLOC)
+if(NOT LEVELDB_DISABLE_CRC32C)
+  check_library_exists(crc32c crc32c_value "" HAVE_CRC32C)
+endif(NOT LEVELDB_DISABLE_CRC32C)
+if(NOT LEVELDB_DISABLE_SNAPPY)
+  check_library_exists(snappy snappy_compress "" HAVE_SNAPPY)
+endif(NOT LEVELDB_DISABLE_SNAPPY)
+if(NOT LEVELDB_DISABLE_TCMALLOC)
+  check_library_exists(tcmalloc malloc "" HAVE_TCMALLOC)
+endif(NOT LEVELDB_DISABLE_TCMALLOC)
 
 include(CheckCXXSymbolExists)
 # Using check_cxx_symbol_exists() instead of check_c_symbol_exists() because


### PR DESCRIPTION
Add cmake options to disable crc32c, snappy, and tcmalloc.