### PR TITLE
kBranching 16 is better than 4 in db benchmarks

### DIFF
--- a/db/skiplist.h
+++ b/db/skiplist.h
@@ -241,7 +241,7 @@ inline void SkipList<Key, Comparator>::Iterator::SeekToLast() {
 template <typename Key, class Comparator>
 int SkipList<Key, Comparator>::RandomHeight() {
   // Increase height with probability 1 in kBranching
-  static const unsigned int kBranching = 4;
+  static const unsigned int kBranching = 16;
   int height = 1;
   while (height < kMaxHeight && ((rnd_.Next() % kBranching) == 0)) {
     height++;


### PR DESCRIPTION
Better performance skiplist can balance all of nodes. The more higher level of the skiplist, the more sparse nodes are.  I tested the db bench that one-sixteenth is better than one-forth