### PR TITLE
Remove unnecessary status check

### DIFF
--- a/table/table.cc
+++ b/table/table.cc
@@ -54,13 +54,11 @@ Status Table::Open(const Options& options, RandomAccessFile* file,
 
   // Read the index block
   BlockContents index_block_contents;
-  if (s.ok()) {
-    ReadOptions opt;
-    if (options.paranoid_checks) {
-      opt.verify_checksums = true;
-    }
-    s = ReadBlock(file, opt, footer.index_handle(), &index_block_contents);
+  ReadOptions opt;
+  if (options.paranoid_checks) {
+    opt.verify_checksums = true;
   }
+  s = ReadBlock(file, opt, footer.index_handle(), &index_block_contents);
 
   if (s.ok()) {
     // We've successfully read the footer and the index block: we're


### PR DESCRIPTION
In Table::Open function, we already judge status just after Decode footer, so the status judge before read index block is duplicate and unnessary,  we can remove it.