### PR TITLE
fix build error: add variable [ConcurrentTest::K]

### DIFF
--- a/db/skiplist_test.cc
+++ b/db/skiplist_test.cc
@@ -280,7 +280,7 @@ class ConcurrentTest {
     }
   }
 };
-
+constexpr uint32_t ConcurrentTest::K;
 // Simple test that does single-threaded testing of the ConcurrentTest
 // scaffolding.
 TEST(SkipTest, ConcurrentWithoutThreads) {


### PR DESCRIPTION
fix a error when build, the error is prompted as "undefined reference to `leveldb::ConcurrentTest::K'"