### PR TITLE
Fix the tests linking error with -DBUILD_SHARED_LIBS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,10 @@ if(LEVELDB_BUILD_TESTS)
   set(build_gmock ON)
 
   # This project is tested using GoogleTest.
+  set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
+  set(BUILD_SHARED_LIBS OFF)
   add_subdirectory("third_party/googletest")
+  set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
 
   # GoogleTest triggers a missing field initializers warning.
   if(LEVELDB_HAVE_NO_MISSING_FIELD_INITIALIZERS)


### PR DESCRIPTION
When build with BUILD_SHARED_LIBS=ON, the tests links with gmock
error:

  /usr/bin/ld: lib/libgmock.so: undefined reference to `testing::internal::ParseInt32(testing::Message const&, char const*, int*)'

which is reported by issue: https://github.com/google/leveldb/issues/770

This patch sets BUILD_SHARED_LIBS=OFF before enter googletest subdirecory,
and restores the previous value later. By doing this, gtest and gmock
will be built as static libraries.

I really think this is a bug in googletest CMakeLists, but I didn't dig
into it too much.

The solution might not be that elegant, but it works, maybe we can find
a better way later.

Signed-off-by: Zhao Junwang <zhjwpku@gmail.com>