### PR TITLE
Fix ldb file wrong level info in log

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -858,7 +858,7 @@ Status DBImpl::FinishCompactionOutputFile(CompactionState* compact,
     delete iter;
     if (s.ok()) {
       Log(options_.info_log, "Generated table #%llu@%d: %lld keys, %lld bytes",
-          (unsigned long long)output_number, compact->compaction->level(),
+          (unsigned long long)output_number, compact->compaction->level() + 1,
           (unsigned long long)current_entries,
           (unsigned long long)current_bytes);
     }


### PR DESCRIPTION
Our operation engineers found wrong level numbers of new generated table files in logs when tracked down some problems of Leveldb.

As the following logs show, 0 is the level of table file 958, but in the next log, file 958 is level 1. Actually compaction also never generate L0 tables files.

```
2020/06/30-15:18:44.422028 7f7f48dfa700 Generated table #958@0: 707856 keys, 34884932 bytes
2020/06/30-15:18:47.923527 7f7f48dfa700 Compacting file, num:958, level:1
```

Just as the comment of the member function `level()` of `Compaction` says
```
  // Return the level that is being compacted.  Inputs from "level"
  // and "level+1" will be merged to produce a set of "level+1" files.
  int level() const { return level_; }
```
So the level of out put files should be `level() + 1`