### PR TITLE
avoid unnecessary memory copy

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -30,10 +30,13 @@ Status BuildTable(const std::string& dbname, Env* env, const Options& options,
 
     TableBuilder* builder = new TableBuilder(options, file);
     meta->smallest.DecodeFrom(iter->key());
+    Slice key;
     for (; iter->Valid(); iter->Next()) {
-      Slice key = iter->key();
-      meta->largest.DecodeFrom(key);
+      key = iter->key();
       builder->Add(key, iter->value());
+    }
+    if(!key.empty()) {
+      meta->largest.DecodeFrom(key);
     }
 
     // Finish and check for builder errors


### PR DESCRIPTION
During the compaction phase, in this function
```
Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
                                Version* base)
```

It will then call

```
BuildTable(const std::string& dbname, Env* env, const Options& options,
                  TableCache* table_cache, Iterator* iter, FileMetaData* meta)
```



In BuildTable function, the code fragment is this:
```
TableBuilder* builder = new TableBuilder(options, file);
    meta->smallest.DecodeFrom(iter->key());
    for (; iter->Valid(); iter->Next()) {
      Slice key = iter->key();
      meta->largest.DecodeFrom(key);
      builder->Add(key, iter->value());
    }
```


In the iterator loop, call meta->largest.DecodeFrom(key)  every time is unnecessary, which will copy every key to meta's largest field. We just need to copy the last key after the iteration is done.

```
bool DecodeFrom(const Slice& s) {
    rep_.assign(s.data(), s.size());
    return !rep_.empty();
  }
```

DecodeFrom just copy the slice to rep_. When there are many keys in Skiplist, and each key is a very long string, the wasting of CPU cycles are considerable.

