### PR TITLE
Simplify the boolean expression.

### DIFF
--- a/benchmarks/db_bench_tree_db.cc
+++ b/benchmarks/db_bench_tree_db.cc
@@ -509,7 +509,7 @@ int main(int argc, char** argv) {
       FLAGS_page_size = n;
     } else if (sscanf(argv[i], "--compression=%d%c", &n, &junk) == 1 &&
                (n == 0 || n == 1)) {
-      FLAGS_compression = (n == 1) ? true : false;
+      FLAGS_compression = n == 1;
     } else if (strncmp(argv[i], "--db=", 5) == 0) {
       FLAGS_db = argv[i] + 5;
     } else {


### PR DESCRIPTION
Looks for boolean expressions involving boolean constants and simplifies them to use the appropriate boolean expression directly.