### PR TITLE
add DB::Get definition to avoid link error when using gcc4.8

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1473,6 +1473,11 @@ Status DB::Delete(const WriteOptions& opt, const Slice& key) {
   return Write(opt, &batch);
 }
 
+Status DB::Get(const ReadOptions& options, const Slice& key, 
+               std::string* value) {
+  return Get(options, key, value);
+}
+
 DB::~DB() = default;
 
 Status DB::Open(const Options& options, const std::string& dbname, DB** dbptr) {


### PR DESCRIPTION
When I using gcc4.8 to build libleveldb.a，and link it to the example code ( https://github.com/google/leveldb/blob/master/doc/index.md )，the compiler complain ：

g++ -o db_writer db_writer.cpp /root/leveldb/libleveldb.a -std=c++11 -lpthread
/tmp/cc60A3F6.o: In function 'main':
db_writer.cpp:(.text+0x255): undefined reference to `leveldb::DB::Get(leveldb::ReadOptions const&, leveldb::Slice const&, std::string*)'
collect2: error: ld returned 1 exit status

But testing with LLVM version 8.1.0 and gcc7.4 the result is fine. I think it is better to be friendly to those weird compilers:)