### PR TITLE
Fixup for compiling benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,10 +381,12 @@ if(LEVELDB_BUILD_TESTS)
 endif(LEVELDB_BUILD_TESTS)
 
 if(LEVELDB_BUILD_BENCHMARKS)
-  set(build_gmock ON)
+  if(NOT LEVELDB_BUILD_TESTS)
+    set(build_gmock ON)
 
-  # Benchmarks needs GoogleTest
-  add_subdirectory("third_party/googletest")
+    # Benchmarks needs GoogleTest
+    add_subdirectory("third_party/googletest")
+  endif(NOT LEVELDB_BUILD_TESTS)
 
   function(leveldb_benchmark bench_file)
     get_filename_component(bench_target_name "${bench_file}" NAME_WE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ else (WIN32)
   set(LEVELDB_PLATFORM_NAME LEVELDB_PLATFORM_POSIX)
 endif (WIN32)
 
-option(LEVELDB_BUILD_TESTS "Build LevelDB's unit tests" ON)
+option(LEVELDB_BUILD_TESTS "Build LevelDB's unit tests" OFF)
 option(LEVELDB_BUILD_BENCHMARKS "Build LevelDB's benchmarks" ON)
 option(LEVELDB_INSTALL "Install LevelDB's header and library" ON)
 
@@ -381,6 +381,11 @@ if(LEVELDB_BUILD_TESTS)
 endif(LEVELDB_BUILD_TESTS)
 
 if(LEVELDB_BUILD_BENCHMARKS)
+  set(build_gmock ON)
+
+  # Benchmarks needs GoogleTest
+  add_subdirectory("third_party/googletest")
+
   function(leveldb_benchmark bench_file)
     get_filename_component(bench_target_name "${bench_file}" NAME_WE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ else (WIN32)
   set(LEVELDB_PLATFORM_NAME LEVELDB_PLATFORM_POSIX)
 endif (WIN32)
 
-option(LEVELDB_BUILD_TESTS "Build LevelDB's unit tests" OFF)
+option(LEVELDB_BUILD_TESTS "Build LevelDB's unit tests" ON)
 option(LEVELDB_BUILD_BENCHMARKS "Build LevelDB's benchmarks" ON)
 option(LEVELDB_INSTALL "Install LevelDB's header and library" ON)
 


### PR DESCRIPTION
DB benchmark targets can not find `gtest` and `gmock` when set  `LEVELDB_BUILD_TESTS` to `OFF` but `LEVELDB_BUILD_BENCHMARKS` to `ON`.