### PR TITLE
fix issue #868

### DIFF
--- a/benchmarks/db_bench.cc
+++ b/benchmarks/db_bench.cc
@@ -130,7 +130,7 @@ class CountComparator : public Comparator {
  public:
   CountComparator(const Comparator* wrapped) : wrapped_(wrapped) {}
   ~CountComparator() override {}
-  int Compare(const Slice& a, const Slice& b) const {
+  int Compare(const Slice& a, const Slice& b) const override{
     count_.fetch_add(1, std::memory_order_relaxed);
     return wrapped_->Compare(a, b);
   }
@@ -149,7 +149,7 @@ class CountComparator : public Comparator {
   void reset() { count_.store(0, std::memory_order_relaxed); }
 
  private:
-  mutable std::atomic<size_t> count_ = 0;
+  mutable std::atomic<size_t> count_ = {0};
   const Comparator* const wrapped_;
 };
 


### PR DESCRIPTION
This PR intends to fix issue #868 
Seems like it was a deleted copy constructor that was getting called. 
May be an issue with come compilers. 
Here is some more detail from the build toolchain:
```
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
...
```