### PR TITLE
hotfix#fix the range predication in log_reader.cc

### DIFF
--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -35,7 +35,7 @@ bool Reader::SkipToInitialBlock() {
   uint64_t block_start_location = initial_offset_ - offset_in_block;
 
   // Don't search a block if we'd be in the trailer
-  if (offset_in_block > kBlockSize - 6) {
+  if (offset_in_block >= kBlockSize - 6) {
     block_start_location += kBlockSize;
   }
 


### PR DESCRIPTION
When a block cell cannot fit a content of kHeaderSize bytes in length, the write will be filled with zeros. I think there is a lack of judgment on whether offset is within the filling interval.