### PR TITLE
Remove dead code

### DIFF
--- a/db/snapshot.h
+++ b/db/snapshot.h
@@ -25,7 +25,7 @@ class SnapshotImpl : public Snapshot {
   friend class SnapshotList;
 
   // SnapshotImpl is kept in a doubly-linked circular list. The SnapshotList
-  // implementation operates on the next/previous fields direcly.
+  // implementation operates on the next/previous fields directly.
   SnapshotImpl* prev_;
   SnapshotImpl* next_;
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -481,17 +481,14 @@ class Harness : public testing::Test {
 
   void TestRandomAccess(Random* rnd, const std::vector<std::string>& keys,
                         const KVMap& data) {
-    static const bool kVerbose = false;
     Iterator* iter = constructor_->NewIterator();
     ASSERT_TRUE(!iter->Valid());
     KVMap::const_iterator model_iter = data.begin();
-    if (kVerbose) std::fprintf(stderr, "---\n");
     for (int i = 0; i < 200; i++) {
       const int toss = rnd->Uniform(5);
       switch (toss) {
         case 0: {
           if (iter->Valid()) {
-            if (kVerbose) std::fprintf(stderr, "Next\n");
             iter->Next();
             ++model_iter;
             ASSERT_EQ(ToString(data, model_iter), ToString(iter));
@@ -500,7 +497,6 @@ class Harness : public testing::Test {
         }
 
         case 1: {
-          if (kVerbose) std::fprintf(stderr, "SeekToFirst\n");
           iter->SeekToFirst();
           model_iter = data.begin();
           ASSERT_EQ(ToString(data, model_iter), ToString(iter));
@@ -510,8 +506,6 @@ class Harness : public testing::Test {
         case 2: {
           std::string key = PickRandomKey(rnd, keys);
           model_iter = data.lower_bound(key);
-          if (kVerbose)
-            std::fprintf(stderr, "Seek '%s'\n", EscapeString(key).c_str());
           iter->Seek(Slice(key));
           ASSERT_EQ(ToString(data, model_iter), ToString(iter));
           break;
@@ -519,7 +513,6 @@ class Harness : public testing::Test {
 
         case 3: {
           if (iter->Valid()) {
-            if (kVerbose) std::fprintf(stderr, "Prev\n");
             iter->Prev();
             if (model_iter == data.begin()) {
               model_iter = data.end();  // Wrap around to invalid value
@@ -532,7 +525,6 @@ class Harness : public testing::Test {
         }
 
         case 4: {
-          if (kVerbose) std::fprintf(stderr, "SeekToLast\n");
           iter->SeekToLast();
           if (keys.empty()) {
             model_iter = data.end();

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -39,6 +39,7 @@ class BloomTest : public testing::Test {
     policy_->CreateFilter(&key_slices[0], static_cast<int>(key_slices.size()),
                           &filter_);
     keys_.clear();
+    if (kVerbose >= 2) DumpFilter();
   }
 
   size_t FilterSize() const { return filter_.size(); }

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -39,7 +39,6 @@ class BloomTest : public testing::Test {
     policy_->CreateFilter(&key_slices[0], static_cast<int>(key_slices.size()),
                           &filter_);
     keys_.clear();
-    if (kVerbose >= 2) DumpFilter();
   }
 
   size_t FilterSize() const { return filter_.size(); }

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -265,7 +265,7 @@ constexpr inline const uint8_t* RoundUp(const uint8_t* pointer) {
 // Determine if the CPU running this program can accelerate the CRC32C
 // calculation.
 static bool CanAccelerateCRC32C() {
-  // port::AcceleretedCRC32C returns zero when unable to accelerate.
+  // port::AcceleratedCRC32C returns zero when unable to accelerate.
   static const char kTestCRCBuffer[] = "TestCRCBuffer";
   static const char kBufSize = sizeof(kTestCRCBuffer) - 1;
   static const uint32_t kTestCRCValue = 0xdcbc59fa;

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -214,7 +214,7 @@ class PosixMmapReadableFile final : public RandomAccessFile {
   // over the ownership of the region.
   //
   // |mmap_limiter| must outlive this instance. The caller must have already
-  // aquired the right to use one mmap region, which will be released when this
+  // acquired the right to use one mmap region, which will be released when this
   // instance is destroyed.
   PosixMmapReadableFile(std::string filename, char* mmap_base, size_t length,
                         Limiter* mmap_limiter)
@@ -728,7 +728,7 @@ class PosixEnv : public Env {
   // Instances are constructed on the thread calling Schedule() and used on the
   // background thread.
   //
-  // This structure is thread-safe beacuse it is immutable.
+  // This structure is thread-safe because it is immutable.
   struct BackgroundWorkItem {
     explicit BackgroundWorkItem(void (*function)(void* arg), void* arg)
         : function(function), arg(arg) {}

--- a/util/env_windows.cc
+++ b/util/env_windows.cc
@@ -661,7 +661,7 @@ class WindowsEnv : public Env {
   // Instances are constructed on the thread calling Schedule() and used on the
   // background thread.
   //
-  // This structure is thread-safe beacuse it is immutable.
+  // This structure is thread-safe because it is immutable.
   struct BackgroundWorkItem {
     explicit BackgroundWorkItem(void (*function)(void* arg), void* arg)
         : function(function), arg(arg) {}


### PR DESCRIPTION
1. Remove dead code.

   In `table/table_test.cc`,  `TestRandomAccess`'s conditions always be false because **static const bool kVerbose** has not been changed since initialization.

   ```c++
   static const bool kVerbose = false;
   ...;
   if (kVerbose) std::fprintf(stderr, "---\n");
   ...;
   if (kVerbose) std::fprintf(stderr, "Next\n");
   ...;
   if (kVerbose) std::fprintf(stderr, "SeekToFirst\n");
   ...;
   if (kVerbose)
               std::fprintf(stderr, "Seek '%s'\n", EscapeString(key).c_str());
   ...;
   if (kVerbose) std::fprintf(stderr, "Prev\n");
   ...;
   if (kVerbose) std::fprintf(stderr, "SeekToLast\n");
   ```

2. Fix some typos in comments.
