### PR TITLE
Improve no_destructor.h

### DIFF
--- a/util/no_destructor.h
+++ b/util/no_destructor.h
@@ -5,7 +5,7 @@
 #ifndef STORAGE_LEVELDB_UTIL_NO_DESTRUCTOR_H_
 #define STORAGE_LEVELDB_UTIL_NO_DESTRUCTOR_H_
 
-#include <type_traits>
+#include <new>
 #include <utility>
 
 namespace leveldb {
@@ -18,12 +18,7 @@ class NoDestructor {
  public:
   template <typename... ConstructorArgTypes>
   explicit NoDestructor(ConstructorArgTypes&&... constructor_args) {
-    static_assert(sizeof(instance_storage_) >= sizeof(InstanceType),
-                  "instance_storage_ is not large enough to hold the instance");
-    static_assert(
-        alignof(decltype(instance_storage_)) >= alignof(InstanceType),
-        "instance_storage_ does not meet the instance's alignment requirement");
-    new (&instance_storage_)
+    ::new (static_cast<void*>(instance_storage_))
         InstanceType(std::forward<ConstructorArgTypes>(constructor_args)...);
   }
 
@@ -33,12 +28,11 @@ class NoDestructor {
   NoDestructor& operator=(const NoDestructor&) = delete;
 
   InstanceType* get() {
-    return reinterpret_cast<InstanceType*>(&instance_storage_);
+    return reinterpret_cast<InstanceType*>(+instance_storage_);
   }
 
  private:
-  typename std::aligned_storage<sizeof(InstanceType),
-                                alignof(InstanceType)>::type instance_storage_;
+  alignas(InstanceType) unsigned char instance_storage_[sizeof(InstanceType)];
 };
 
 }  // namespace leveldb


### PR DESCRIPTION
1. Removed dependency on `std::aligned_storage` (which will be deprecated in C++23; see also https://github.com/cplusplus/papers/issues/197).
2. Removed redundant `static_assert`s.
3. Guaranteed the placement new-expression calls global `operator new`.