### PR TITLE
Fix log_reader.h documentation error

### DIFF
--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -24,7 +24,7 @@ class Reader {
    public:
     virtual ~Reporter();
 
-    // Some corruption was detected.  "size" is the approximate number
+    // Some corruption was detected.  "bytes" is the approximate number
     // of bytes dropped due to the corruption.
     virtual void Corruption(size_t bytes, const Status& status) = 0;
   };


### PR DESCRIPTION
In accordance with issue #878, I have rectified  `log_reader.h` [Line 27](https://github.com/google/leveldb/blob/1998c0ef15f0fb64994e165230473337f041fd8c/db/log_reader.h#L27).
