### PR TITLE
Drop more invalid entries for same key.

### DIFF
--- a/db/snapshot.h
+++ b/db/snapshot.h
@@ -5,6 +5,8 @@
 #ifndef STORAGE_LEVELDB_DB_SNAPSHOT_H_
 #define STORAGE_LEVELDB_DB_SNAPSHOT_H_
 
+#include <vector>
+
 #include "db/dbformat.h"
 #include "leveldb/db.h"
 
@@ -51,6 +53,16 @@ class SnapshotList {
   SnapshotImpl* newest() const {
     assert(!empty());
     return head_.prev_;
+  }
+
+  void GetSequenceNumberList(std::vector<SequenceNumber> *list_) {
+    assert(list_->empty());
+    if (empty()) return;
+    SnapshotImpl* cur = head_.next_;  // get oldest;
+    while (cur != &head_) {
+      list_->push_back(cur->sequence_number());
+      cur = cur->next_;
+    }
   }
 
   // Creates a SnapshotImpl and appends it to the end of the list.


### PR DESCRIPTION
In the old approach to dropping, there may be invalid entries that can't be removed, see more in https://github.com/google/leveldb/issues/898
For each snapshot, there may exists multiple entries for the same key which sequence number less or equal to it, what we really need is the closest one. A vector of snapshots (MaxSequenceNumber will be appended to the end) is used to help determine if an entry should be dropped. When a user key occurs first time, snapshots reverse iterator points to rbegin. If we found current key's sequence number <= iterator, then it's the closest one to previous snapshot.
I add a new test `HiddenValuesAreRemoved2` (rename: `HiddenValuesAreRemoved` to `HiddenValuesAreRemoved1`) to test such case.