### PR TITLE
Replace "(Random::Next() % kBranching) == 0" with "Random::OneIn(kBranching)"  

### DIFF
--- a/db/skiplist.h
+++ b/db/skiplist.h
@@ -243,7 +243,7 @@ int SkipList<Key, Comparator>::RandomHeight() {
   // Increase height with probability 1 in kBranching
   static const unsigned int kBranching = 4;
   int height = 1;
-  while (height < kMaxHeight && ((rnd_.Next() % kBranching) == 0)) {
+  while (height < kMaxHeight && rnd_.OneIn(kBranching)) {
     height++;
   }
   assert(height > 0);


### PR DESCRIPTION
There are already existing functions in [random.h](https://github.com/google/leveldb/blob/5d94ad4d95c09d3ac203ddaf9922e55e730706a8/util/random.h#L53), but the original expression is still used [here](https://github.com/google/leveldb/blob/5d94ad4d95c09d3ac203ddaf9922e55e730706a8/db/skiplist.h#L246)