### PR TITLE
fix manifest_file_number_ when recover

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -805,6 +805,7 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
     // No reason to unlock *mu here since we only hit this path in the
     // first call to LogAndApply (when opening the database).
     assert(descriptor_file_ == nullptr);
+    manifest_file_number_ = NewFileNumber();
     new_manifest_file = DescriptorFileName(dbname_, manifest_file_number_);
     edit->SetNextFile(next_file_number_);
     s = env_->NewWritableFile(new_manifest_file, &descriptor_file_);
@@ -971,8 +972,7 @@ Status VersionSet::Recover(bool* save_manifest) {
     // Install recovered version
     Finalize(v);
     AppendVersion(v);
-    manifest_file_number_ = next_file;
-    next_file_number_ = next_file + 1;
+    next_file_number_ = next_file;
     last_sequence_ = last_sequence;
     log_number_ = log_number;
     prev_log_number_ = prev_log_number;


### PR DESCRIPTION
#904 
in VersionSet::Recover, we set manifest_file_number_ to be the next_file_number_ that we recovered from manifest file
https://github.com/google/leveldb/blob/f57513a1d6c99636fc5b710150d0b93713af4e43/db/version_set.cc#L974
and we use this manifest_file_number_ to create a new manifest file when recover
https://github.com/google/leveldb/blob/f57513a1d6c99636fc5b710150d0b93713af4e43/db/version_set.cc#L808
this assumes that the next_file_number_ that we recovered from manifest file, is the most update to date next_file_number_ in VersionSet when we are about to create the new manifest file. 
this is dangerous, since there might be file not recorded in the old manifest file is using the next_file_number_ that we recovered from the old manifest file