### PR TITLE
Find Threads dependency in the package config file

### DIFF
--- a/cmake/leveldbConfig.cmake.in
+++ b/cmake/leveldbConfig.cmake.in
@@ -4,6 +4,9 @@
 
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/leveldbTargets.cmake")
 
 check_required_components(leveldb)


### PR DESCRIPTION
Downstream projects must also find the Threads package so the Threads
package should be found in the configuration file to ensure this (as
explained in the 'Creating a Package Configuration File' section of the
CMake Importing Exporting Guide).

This PR addresses issue #907. I used the name "Jason Vaccaro" to sign the CLA.