### PR TITLE
Add shlwapi to leveldb target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,9 @@ endif(HAVE_SNAPPY)
 if(HAVE_TCMALLOC)
   target_link_libraries(leveldb tcmalloc)
 endif(HAVE_TCMALLOC)
+if(WIN32)
+  target_link_libraries(leveldb shlwapi)
+endif(WIN32)
 
 # Needed by port_stdcxx.h
 find_package(Threads REQUIRED)


### PR DESCRIPTION
When cross-compiling using MinGW over Debian 10, the install part complained of shlwapi library missing.
I have included it with this pull request.