### PR TITLE
Fixed incorrect limit in env_posix_test.cc

### DIFF
--- a/util/env_posix_test.cc
+++ b/util/env_posix_test.cc
@@ -243,8 +243,8 @@ TEST_F(EnvPosixTest, TestCloseOnExecRandomAccessFile) {
   // Exhaust the RandomAccessFile mmap limit. This way, the test
   // RandomAccessFile instance below is backed by a file descriptor, not by an
   // mmap region.
-  leveldb::RandomAccessFile* mmapped_files[kReadOnlyFileLimit] = {nullptr};
-  for (int i = 0; i < kReadOnlyFileLimit; i++) {
+  leveldb::RandomAccessFile* mmapped_files[kMMapLimit];
+  for (int i = 0; i < kMMapLimit; i++) {
     ASSERT_LEVELDB_OK(env_->NewRandomAccessFile(file_path, &mmapped_files[i]));
   }
 
@@ -253,7 +253,7 @@ TEST_F(EnvPosixTest, TestCloseOnExecRandomAccessFile) {
   CheckCloseOnExecDoesNotLeakFDs(open_fds);
   delete file;
 
-  for (int i = 0; i < kReadOnlyFileLimit; i++) {
+  for (int i = 0; i < kMMapLimit; i++) {
     delete mmapped_files[i];
   }
   ASSERT_LEVELDB_OK(env_->RemoveFile(file_path));


### PR DESCRIPTION
```
  // Exhaust the RandomAccessFile mmap limit. This way, the test
  // RandomAccessFile instance below is backed by a file descriptor, not by an
  // mmap region.
  leveldb::RandomAccessFile* mmapped_files[kReadOnlyFileLimit] = {nullptr};
  for (int i = 0; i < kReadOnlyFileLimit; i++) {
    ASSERT_LEVELDB_OK(env_->NewRandomAccessFile(file_path, &mmapped_files[i]));
  }
```
In above code; we should use kMMapLimit to exhaust the RandomAccessFile mmap;
Otherwise when kMMapLimit is not equals to kReadOnlyFileLimit, this test would failed