### PR TITLE
Remove <pthread.h> include

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -4,7 +4,6 @@
 
 #include <dirent.h>
 #include <fcntl.h>
-#include <pthread.h>
 #include <sys/mman.h>
 #ifndef __Fuchsia__
 #include <sys/resource.h>


### PR DESCRIPTION
Since https://github.com/google/leveldb/commit/d177a026, pthreads is not used directly and leveldb relies on the C++11 threading primitives.