### PR TITLE
Use FindFile to implement Compaction::IsBaseLevelForKey

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -696,9 +696,9 @@ TEST_F(DBTest, IterateOverEmptySnapshot) {
 
 TEST_F(DBTest, GetLevel0Ordering) {
   do {
-    // Check that we process level-2 files in correct order.  The code
-    // below generates two level-2 files where the earlier one comes
-    // before the later one in the level-2 file list since the earlier
+    // Check that we process level-0 files in correct order.  The code
+    // below generates two level-0 files where the earlier one comes
+    // before the later one in the level-0 file list since the earlier
     // one has a smaller "smallest" key.
     ASSERT_LEVELDB_OK(Put("bar", "b"));
     ASSERT_LEVELDB_OK(Put("foo", "v1"));

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -696,9 +696,9 @@ TEST_F(DBTest, IterateOverEmptySnapshot) {
 
 TEST_F(DBTest, GetLevel0Ordering) {
   do {
-    // Check that we process level-0 files in correct order.  The code
-    // below generates two level-0 files where the earlier one comes
-    // before the later one in the level-0 file list since the earlier
+    // Check that we process level-2 files in correct order.  The code
+    // below generates two level-2 files where the earlier one comes
+    // before the later one in the level-2 file list since the earlier
     // one has a smaller "smallest" key.
     ASSERT_LEVELDB_OK(Put("bar", "b"));
     ASSERT_LEVELDB_OK(Put("foo", "v1"));

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -43,7 +43,8 @@ class WritableFile;
 // Return files.size() if there is no such file.
 // REQUIRES: "files" contains a sorted list of non-overlapping files.
 int FindFile(const InternalKeyComparator& icmp,
-             const std::vector<FileMetaData*>& files, const Slice& key);
+             const std::vector<FileMetaData*>& files, const Slice& key,
+             bool use_user_comparator = false);
 
 // Returns true iff some file in "files" overlaps the user key range
 // [*smallest,*largest].
@@ -378,14 +379,6 @@ class Compaction {
   bool seen_key_;             // Some output key has been seen
   int64_t overlapped_bytes_;  // Bytes of overlap between current output
                               // and grandparent files
-
-  // State for implementing IsBaseLevelForKey
-
-  // level_ptrs_ holds indices into input_version_->levels_: our state
-  // is that we are positioned at one of the file ranges for each
-  // higher level than the ones involved in this compaction (i.e. for
-  // all L >= level_ + 2).
-  size_t level_ptrs_[config::kNumLevels];
 };
 
 }  // namespace leveldb


### PR DESCRIPTION
we can add flag to identify we should use which comparator in FindFile. use user_comparator to implement 
Compaction::IsBaseLevelForKey. Do this we can  use binary search.  we don need level_ptrs_. I test 