### PR TITLE
rm redundant code: SetNextFile has already been called before in this…

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -806,7 +806,6 @@ Status VersionSet::LogAndApply(VersionEdit* edit, port::Mutex* mu) {
     // first call to LogAndApply (when opening the database).
     assert(descriptor_file_ == nullptr);
     new_manifest_file = DescriptorFileName(dbname_, manifest_file_number_);
-    edit->SetNextFile(next_file_number_);
     s = env_->NewWritableFile(new_manifest_file, &descriptor_file_);
     if (s.ok()) {
       descriptor_log_ = new log::Writer(descriptor_file_);


### PR DESCRIPTION
`edit->SetNextFile` has already been called before, there is no need to call it again.