### PR TITLE
`std::memory_order::memory_order_relaxed` -> `std::memory_order_relaxed`

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -870,7 +870,7 @@ class SingletonEnv {
  public:
   SingletonEnv() {
 #if !defined(NDEBUG)
-    env_initialized_.store(true, std::memory_order::memory_order_relaxed);
+    env_initialized_.store(true, std::memory_order_relaxed);
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
@@ -887,7 +887,7 @@ class SingletonEnv {
 
   static void AssertEnvNotInitialized() {
 #if !defined(NDEBUG)
-    assert(!env_initialized_.load(std::memory_order::memory_order_relaxed));
+    assert(!env_initialized_.load(std::memory_order_relaxed));
 #endif  // !defined(NDEBUG)
   }
 


### PR DESCRIPTION
`std::memory_order::memory_order_relaxed` is removed since C++ 20: https://en.cppreference.com/w/cpp/atomic/memory_order. 

Running `cmake -DCMAKE_CXX_STANDARD=20 .. && cmake --build .` gives the following error:

```
leveldb/util/env_posix.cc:890:35: error: no member named 'memory_order_relaxed' in 'std::memory_order'; did you mean 'std::memory_order_relaxed'?
    assert(!env_initialized_.load(std::memory_order::memory_order_relaxed));
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                  std::memory_order_relaxed
```

This PR fixed this issue. 