### PR TITLE
remove useless code in cache.h

### DIFF
--- a/include/leveldb/cache.h
+++ b/include/leveldb/cache.h
@@ -96,14 +96,6 @@ class LEVELDB_EXPORT Cache {
   // Return an estimate of the combined charges of all elements stored in the
   // cache.
   virtual size_t TotalCharge() const = 0;
-
- private:
-  void LRU_Remove(Handle* e);
-  void LRU_Append(Handle* e);
-  void Unref(Handle* e);
-
-  struct Rep;
-  Rep* rep_;
 };
 
 }  // namespace leveldb


### PR DESCRIPTION
Since https://github.com/google/leveldb/commit/e3584f9c28833ec0530b39540ffd406ee41dbc3a the `LRUCache` doesn't inherit from `Cache` anymore. It's replaced by `ShardedLRUCache`.

The codes in `cache.h` is no longer used. This PR deletes them.