### PR TITLE
support lz4 compress&uncompress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ include(CheckLibraryExists)
 check_library_exists(crc32c crc32c_value "" HAVE_CRC32C)
 check_library_exists(snappy snappy_compress "" HAVE_SNAPPY)
 check_library_exists(tcmalloc malloc "" HAVE_TCMALLOC)
+check_library_exists(lz4 lz4compress "" HAVE_LZ4)
 
 include(CheckCXXSymbolExists)
 # Using check_cxx_symbol_exists() instead of check_c_symbol_exists() because
@@ -276,6 +277,10 @@ endif(HAVE_SNAPPY)
 if(HAVE_TCMALLOC)
   target_link_libraries(leveldb tcmalloc)
 endif(HAVE_TCMALLOC)
+
+if(HAVE_LZ4)
+  target_link_libraries(leveldb lz4)
+endif(HAVE_LZ4)
 
 # Needed by port_stdcxx.h
 find_package(Threads REQUIRED)

--- a/benchmarks/db_bench.cc
+++ b/benchmarks/db_bench.cc
@@ -60,7 +60,9 @@ static const char* FLAGS_benchmarks =
     "fill100K,"
     "crc32c,"
     "snappycomp,"
-    "snappyuncomp,";
+    "snappyuncomp,"
+    "lz4comp,"
+    "lz4uncomp,";
 
 // Number of key/values to place in database
 static int FLAGS_num = 1000000;
@@ -576,6 +578,10 @@ class Benchmark {
         method = &Benchmark::SnappyCompress;
       } else if (name == Slice("snappyuncomp")) {
         method = &Benchmark::SnappyUncompress;
+      } else if (name == Slice("lz4comp")) {
+        method = &Benchmark::Lz4Compress;
+      } else if (name == Slice("lz4uncomp")) {
+        method = &Benchmark::Lz4Uncompress;
       } else if (name == Slice("heapprofile")) {
         HeapProfile();
       } else if (name == Slice("stats")) {
@@ -751,6 +757,55 @@ class Benchmark {
 
     if (!ok) {
       thread->stats.AddMessage("(snappy failure)");
+    } else {
+      thread->stats.AddBytes(bytes);
+    }
+  }
+
+  void Lz4Compress(ThreadState* thread) {
+    RandomGenerator gen;
+    Slice input = gen.Generate(Options().block_size);
+    int64_t bytes = 0;
+    int64_t produced = 0;
+    bool ok = true;
+    std::string compressed;
+    while (ok && bytes < 1024 * 1048576) {  // Compress 1G
+      ok = port::Lz4_Compress(input.data(), input.size(), &compressed);
+      // std::fprintf(stdout, "Lz4_Compress
+      // compressed.size():%lu,compressed:%s\n",compressed.size(),compressed.c_str());
+      produced += compressed.size();
+      bytes += input.size();
+      thread->stats.FinishedSingleOp();
+    }
+    if (!ok) {
+      thread->stats.AddMessage("(Lz4Compress failure)");
+    } else {
+      char buf[100];
+      std::snprintf(buf, sizeof(buf), "(output: %.1f)",
+                    (produced * 100.0) / bytes);
+      thread->stats.AddMessage(buf);
+      thread->stats.AddBytes(bytes);
+    }
+  }
+
+  void Lz4Uncompress(ThreadState* thread) {
+    RandomGenerator gen;
+    Slice input = gen.Generate(Options().block_size);
+    std::string compressed;
+    bool ok = port::Lz4_Compress(input.data(), input.size(), &compressed);
+    int64_t bytes = 0;
+    char* uncompressed = new char[input.size()];
+    while (ok && bytes < 1024 * 1048576) {  // Compress 1G
+      ok = port::Lz4_UnCompress(compressed.data(), compressed.size(),
+                                uncompressed, input.size());
+      bytes += input.size();
+      thread->stats.FinishedSingleOp();
+    }
+
+    delete[] uncompressed;
+
+    if (!ok) {
+      thread->stats.AddMessage("(Lz4Uncompress failure)");
     } else {
       thread->stats.AddBytes(bytes);
     }

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -26,7 +26,8 @@ enum CompressionType {
   // NOTE: do not change the values of existing entries, as these are
   // part of the persistent format on disk.
   kNoCompression = 0x0,
-  kSnappyCompression = 0x1
+  kSnappyCompression = 0x1,
+  kLz4Compression = 0x2,
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/leveldb/table_builder.h
+++ b/include/leveldb/table_builder.h
@@ -82,7 +82,8 @@ class LEVELDB_EXPORT TableBuilder {
  private:
   bool ok() const { return status().ok(); }
   void WriteBlock(BlockBuilder* block, BlockHandle* handle);
-  void WriteRawBlock(const Slice& data, CompressionType, BlockHandle* handle);
+  void WriteRawBlock(const Slice& data, CompressionType, BlockHandle* handle,
+                     size_t rawsize = 0);
 
   struct Rep;
   Rep* rep_;

--- a/table/format.cc
+++ b/table/format.cc
@@ -70,6 +70,7 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
   // Read the block contents as well as the type/crc footer.
   // See table_builder.cc for the code that built this structure.
   size_t n = static_cast<size_t>(handle.size());
+  size_t rawsize = static_cast<size_t>(handle.rawsize());
   char* buf = new char[n + kBlockTrailerSize];
   Slice contents;
   Status s = file->Read(handle.offset(), n + kBlockTrailerSize, &contents, buf);
@@ -126,6 +127,19 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
       }
       delete[] buf;
       result->data = Slice(ubuf, ulength);
+      result->heap_allocated = true;
+      result->cachable = true;
+      break;
+    }
+    case kLz4Compression: {
+      char* ubuf = new char[rawsize];
+      if (!port::Lz4_UnCompress(data, n, ubuf, rawsize)) {
+        delete[] buf;
+        delete[] ubuf;
+        return Status::Corruption("corrupted compressed block contents");
+      }
+      delete[] buf;
+      result->data = Slice(ubuf, rawsize);
       result->heap_allocated = true;
       result->cachable = true;
       break;

--- a/table/format.h
+++ b/table/format.h
@@ -35,12 +35,17 @@ class BlockHandle {
   uint64_t size() const { return size_; }
   void set_size(uint64_t size) { size_ = size; }
 
+  // The size of the raw stored block
+  uint64_t rawsize() const { return rawsize_; }
+  void set_rawsize(uint64_t size) { rawsize_ = size; }
+
   void EncodeTo(std::string* dst) const;
   Status DecodeFrom(Slice* input);
 
  private:
   uint64_t offset_;
   uint64_t size_;
+  uint64_t rawsize_;
 };
 
 // Footer encapsulates the fixed information stored at the tail

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -826,4 +826,40 @@ TEST(TableTest, ApproximateOffsetOfCompressed) {
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"), 2 * min_z, 2 * max_z));
 }
 
+TEST(TableTest, ApproximateOffsetOfLZ4Compressed) {
+  if (!SnappyCompressionSupported()) {
+    std::fprintf(stderr, "skipping compression tests\n");
+    return;
+  }
+
+  Random rnd(301);
+  TableConstructor c(BytewiseComparator());
+  std::string tmp;
+  c.Add("k01", "hello");
+  c.Add("k02", test::CompressibleString(&rnd, 0.25, 10000, &tmp));
+  c.Add("k03", "hello3");
+  c.Add("k04", test::CompressibleString(&rnd, 0.25, 10000, &tmp));
+  std::vector<std::string> keys;
+  KVMap kvmap;
+  Options options;
+  options.block_size = 1024;
+  options.compression = kLz4Compression;
+  c.Finish(options, &keys, &kvmap);
+
+  // Expected upper and lower bounds of space used by compressible strings.
+  static const int kSlop = 1000;  // Compressor effectiveness varies.
+  const int expected = 2500;      // 10000 * compression ratio (0.25)
+  const int min_z = expected - kSlop;
+  const int max_z = expected + kSlop;
+
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("abc"), 0, kSlop));
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("k01"), 0, kSlop));
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("k02"), 0, kSlop));
+  // Have now emitted a large compressible string, so adjust expected offset.
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("k03"), min_z, max_z));
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("k04"), min_z, max_z));
+  // Have now emitted two large compressible strings, so adjust expected offset.
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"), 2 * min_z, 2 * max_z));
+}
+
 }  // namespace leveldb


### PR DESCRIPTION
please help to review my pr. 
as discussed in https://github.com/google/leveldb/issues/721 , lz4 compress show a good performance on compress&uncompress . I have tested in leveldb_bench :
root@RC803390482:/opt/opensource/level-lz4/leveldb/build# ./db_bench 
LevelDB:    version 1.23
Date:       Wed Jan 12 20:04:52 2022
CPU:        4 * Intel(R) Xeon(R) Gold 6150 CPU @ 2.70GHz
CPUCache:   25344 KB
Keys:       16 bytes each
Values:     100 bytes each (50 bytes after compression)
Entries:    1000000
RawSize:    110.6 MB (estimated)
FileSize:   62.9 MB (estimated)
------------------------------------------------
fillseq      :       2.441 micros/op;   45.3 MB/s     
fillsync     :    2612.438 micros/op;    0.0 MB/s (1000 ops)
fillrandom   :       5.780 micros/op;   19.1 MB/s     
overwrite    :      10.133 micros/op;   10.9 MB/s     
readrandom   :      12.942 micros/op; (864322 of 1000000 found)
readrandom   :      11.557 micros/op; (864083 of 1000000 found)
readseq      :       0.348 micros/op;  317.5 MB/s    
readreverse  :       0.439 micros/op;  251.8 MB/s    
compact      : 2026325.000 micros/op;
readrandom   :       9.479 micros/op; (864105 of 1000000 found)
readseq      :       0.377 micros/op;  293.8 MB/s    
readreverse  :       0.422 micros/op;  262.4 MB/s    
fill100K     :    2655.037 micros/op;   35.9 MB/s (1000 ops)
crc32c       :       1.346 micros/op; 2901.7 MB/s (4K per op)
snappycomp   :      40.606 micros/op;   96.2 MB/s (output: 55.1%)
snappyuncomp :       2.695 micros/op; 1449.3 MB/s    
lz4comp      :       4.279 micros/op;  912.9 MB/s (output: 55.2)
lz4uncomp    :       0.494 micros/op; 7905.0 MB/s  