### PR TITLE
optimize includes

### DIFF
--- a/benchmarks/db_bench.cc
+++ b/benchmarks/db_bench.cc
@@ -2,10 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include <sys/types.h>
-
 #include <atomic>
-#include <cstdio>
 #include <cstdlib>
 
 #include "leveldb/cache.h"
@@ -13,8 +10,10 @@
 #include "leveldb/db.h"
 #include "leveldb/env.h"
 #include "leveldb/filter_policy.h"
+#include "leveldb/iterator.h"
+#include "leveldb/options.h"
 #include "leveldb/write_batch.h"
-#include "port/port.h"
+
 #include "util/crc32c.h"
 #include "util/histogram.h"
 #include "util/mutexlock.h"

--- a/db/autocompact_test.cc
+++ b/db/autocompact_test.cc
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "gtest/gtest.h"
 #include "db/db_impl.h"
+
 #include "leveldb/cache.h"
-#include "leveldb/db.h"
+#include "leveldb/iterator.h"
+
 #include "util/testutil.h"
 
 namespace leveldb {

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "db/builder.h"
-
-#include "db/dbformat.h"
 #include "db/filename.h"
 #include "db/table_cache.h"
 #include "db/version_edit.h"
-#include "leveldb/db.h"
+
 #include "leveldb/env.h"
 #include "leveldb/iterator.h"
+#include "leveldb/table_builder.h"
 
 namespace leveldb {
 

--- a/db/builder.h
+++ b/db/builder.h
@@ -5,6 +5,8 @@
 #ifndef STORAGE_LEVELDB_DB_BUILDER_H_
 #define STORAGE_LEVELDB_DB_BUILDER_H_
 
+#include <string>
+
 #include "leveldb/status.h"
 
 namespace leveldb {

--- a/db/c.cc
+++ b/db/c.cc
@@ -4,10 +4,7 @@
 
 #include "leveldb/c.h"
 
-#include <string.h>
-
-#include <cstdint>
-#include <cstdlib>
+#include <cstring>
 
 #include "leveldb/cache.h"
 #include "leveldb/comparator.h"
@@ -16,7 +13,6 @@
 #include "leveldb/filter_policy.h"
 #include "leveldb/iterator.h"
 #include "leveldb/options.h"
-#include "leveldb/status.h"
 #include "leveldb/write_batch.h"
 
 using leveldb::Cache;

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -2,18 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include <sys/types.h>
-
-#include "gtest/gtest.h"
 #include "db/db_impl.h"
 #include "db/filename.h"
 #include "db/log_format.h"
-#include "db/version_set.h"
+
 #include "leveldb/cache.h"
-#include "leveldb/db.h"
-#include "leveldb/table.h"
+#include "leveldb/iterator.h"
 #include "leveldb/write_batch.h"
+
 #include "util/logging.h"
+#include "util/random.h"
 #include "util/testutil.h"
 
 namespace leveldb {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -4,17 +4,8 @@
 
 #include "db/db_impl.h"
 
-#include <algorithm>
-#include <atomic>
-#include <cstdint>
-#include <cstdio>
-#include <set>
-#include <string>
-#include <vector>
-
 #include "db/builder.h"
 #include "db/db_iter.h"
-#include "db/dbformat.h"
 #include "db/filename.h"
 #include "db/log_reader.h"
 #include "db/log_writer.h"
@@ -22,16 +13,13 @@
 #include "db/table_cache.h"
 #include "db/version_set.h"
 #include "db/write_batch_internal.h"
-#include "leveldb/db.h"
+#include <algorithm>
+
 #include "leveldb/env.h"
-#include "leveldb/status.h"
-#include "leveldb/table.h"
+#include "leveldb/iterator.h"
 #include "leveldb/table_builder.h"
-#include "port/port.h"
-#include "table/block.h"
+
 #include "table/merger.h"
-#include "table/two_level_iterator.h"
-#include "util/coding.h"
 #include "util/logging.h"
 #include "util/mutexlock.h"
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -5,18 +5,19 @@
 #ifndef STORAGE_LEVELDB_DB_DB_IMPL_H_
 #define STORAGE_LEVELDB_DB_DB_IMPL_H_
 
-#include <atomic>
-#include <deque>
-#include <set>
-#include <string>
-
-#include "db/dbformat.h"
 #include "db/log_writer.h"
 #include "db/snapshot.h"
-#include "leveldb/db.h"
+#include <atomic>
+#include <deque>
+#include <map>
+#include <set>
+#include <vector>
+
 #include "leveldb/env.h"
-#include "port/port.h"
-#include "port/thread_annotations.h"
+#include "leveldb/options.h"
+#include "leveldb/status.h"
+
+#include "port/port_stdcxx.h"
 
 namespace leveldb {
 

--- a/db/db_iter.cc
+++ b/db/db_iter.cc
@@ -2,16 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "db/db_iter.h"
-
 #include "db/db_impl.h"
-#include "db/dbformat.h"
-#include "db/filename.h"
-#include "leveldb/env.h"
+
 #include "leveldb/iterator.h"
-#include "port/port.h"
-#include "util/logging.h"
-#include "util/mutexlock.h"
+
 #include "util/random.h"
 
 namespace leveldb {

--- a/db/db_iter.h
+++ b/db/db_iter.h
@@ -5,10 +5,9 @@
 #ifndef STORAGE_LEVELDB_DB_DB_ITER_H_
 #define STORAGE_LEVELDB_DB_DB_ITER_H_
 
-#include <cstdint>
-
 #include "db/dbformat.h"
-#include "leveldb/db.h"
+
+#include "leveldb/iterator.h"
 
 namespace leveldb {
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -2,26 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "leveldb/db.h"
-
-#include <atomic>
-#include <cinttypes>
-#include <string>
-
-#include "gtest/gtest.h"
 #include "db/db_impl.h"
 #include "db/filename.h"
-#include "db/version_set.h"
-#include "db/write_batch_internal.h"
+
 #include "leveldb/cache.h"
-#include "leveldb/env.h"
-#include "leveldb/filter_policy.h"
-#include "leveldb/table.h"
-#include "port/port.h"
-#include "port/thread_annotations.h"
-#include "util/hash.h"
+#include "leveldb/iterator.h"
+#include "leveldb/write_batch.h"
+
 #include "util/logging.h"
 #include "util/mutexlock.h"
+#include "util/random.h"
 #include "util/testutil.h"
 
 namespace leveldb {

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -4,11 +4,10 @@
 
 #include "db/dbformat.h"
 
-#include <cstdio>
+#include <cstring>
 #include <sstream>
 
-#include "port/port.h"
-#include "util/coding.h"
+#include "util/logging.h"
 
 namespace leveldb {
 

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -5,17 +5,11 @@
 #ifndef STORAGE_LEVELDB_DB_DBFORMAT_H_
 #define STORAGE_LEVELDB_DB_DBFORMAT_H_
 
-#include <cstddef>
-#include <cstdint>
-#include <string>
-
 #include "leveldb/comparator.h"
-#include "leveldb/db.h"
 #include "leveldb/filter_policy.h"
 #include "leveldb/slice.h"
-#include "leveldb/table_builder.h"
+
 #include "util/coding.h"
-#include "util/logging.h"
 
 namespace leveldb {
 

--- a/db/dbformat_test.cc
+++ b/db/dbformat_test.cc
@@ -4,8 +4,7 @@
 
 #include "db/dbformat.h"
 
-#include "gtest/gtest.h"
-#include "util/logging.h"
+#include <gtest/gtest_pred_impl.h>
 
 namespace leveldb {
 

--- a/db/dumpfile.cc
+++ b/db/dumpfile.cc
@@ -2,21 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "leveldb/dumpfile.h"
-
-#include <cstdio>
-
-#include "db/dbformat.h"
 #include "db/filename.h"
 #include "db/log_reader.h"
 #include "db/version_edit.h"
 #include "db/write_batch_internal.h"
+
 #include "leveldb/env.h"
 #include "leveldb/iterator.h"
 #include "leveldb/options.h"
-#include "leveldb/status.h"
 #include "leveldb/table.h"
-#include "leveldb/write_batch.h"
+
 #include "util/logging.h"
 
 namespace leveldb {

--- a/db/filename.cc
+++ b/db/filename.cc
@@ -4,11 +4,8 @@
 
 #include "db/filename.h"
 
-#include <cassert>
-#include <cstdio>
-
-#include "db/dbformat.h"
 #include "leveldb/env.h"
+
 #include "util/logging.h"
 
 namespace leveldb {

--- a/db/filename.h
+++ b/db/filename.h
@@ -10,9 +10,7 @@
 #include <cstdint>
 #include <string>
 
-#include "leveldb/slice.h"
 #include "leveldb/status.h"
-#include "port/port.h"
 
 namespace leveldb {
 

--- a/db/filename_test.cc
+++ b/db/filename_test.cc
@@ -4,10 +4,9 @@
 
 #include "db/filename.h"
 
+#include "leveldb/slice.h"
+
 #include "gtest/gtest.h"
-#include "db/dbformat.h"
-#include "port/port.h"
-#include "util/logging.h"
 
 namespace leveldb {
 

--- a/db/leveldbutil.cc
+++ b/db/leveldbutil.cc
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include <cstdio>
-
 #include "leveldb/dumpfile.h"
 #include "leveldb/env.h"
-#include "leveldb/status.h"
 
 namespace leveldb {
 namespace {

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -4,9 +4,8 @@
 
 #include "db/log_reader.h"
 
-#include <cstdio>
-
 #include "leveldb/env.h"
+
 #include "util/coding.h"
 #include "util/crc32c.h"
 

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -5,8 +5,6 @@
 #ifndef STORAGE_LEVELDB_DB_LOG_READER_H_
 #define STORAGE_LEVELDB_DB_LOG_READER_H_
 
-#include <cstdint>
-
 #include "db/log_format.h"
 #include "leveldb/slice.h"
 #include "leveldb/status.h"

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -4,9 +4,8 @@
 
 #include "db/log_writer.h"
 
-#include <cstdint>
-
 #include "leveldb/env.h"
+
 #include "util/coding.h"
 #include "util/crc32c.h"
 

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -5,10 +5,10 @@
 #ifndef STORAGE_LEVELDB_DB_LOG_WRITER_H_
 #define STORAGE_LEVELDB_DB_LOG_WRITER_H_
 
-#include <cstdint>
-
 #include "db/log_format.h"
-#include "leveldb/slice.h"
+#include <cstdint>
+#include <cstddef>
+
 #include "leveldb/status.h"
 
 namespace leveldb {

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -3,11 +3,11 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "db/memtable.h"
-#include "db/dbformat.h"
-#include "leveldb/comparator.h"
-#include "leveldb/env.h"
+
+#include <cstring>
+
 #include "leveldb/iterator.h"
-#include "util/coding.h"
+#include "leveldb/status.h"
 
 namespace leveldb {
 

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -5,12 +5,10 @@
 #ifndef STORAGE_LEVELDB_DB_MEMTABLE_H_
 #define STORAGE_LEVELDB_DB_MEMTABLE_H_
 
-#include <string>
-
 #include "db/dbformat.h"
 #include "db/skiplist.h"
-#include "leveldb/db.h"
-#include "util/arena.h"
+
+#include "leveldb/iterator.h"
 
 namespace leveldb {
 

--- a/db/recovery_test.cc
+++ b/db/recovery_test.cc
@@ -2,16 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "gtest/gtest.h"
 #include "db/db_impl.h"
 #include "db/filename.h"
-#include "db/version_set.h"
 #include "db/write_batch_internal.h"
-#include "leveldb/db.h"
-#include "leveldb/env.h"
-#include "leveldb/write_batch.h"
-#include "util/logging.h"
+
 #include "util/testutil.h"
+
+#include "log_writer.h"
 
 namespace leveldb {
 

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -26,7 +26,6 @@
 
 #include "db/builder.h"
 #include "db/db_impl.h"
-#include "db/dbformat.h"
 #include "db/filename.h"
 #include "db/log_reader.h"
 #include "db/log_writer.h"
@@ -34,9 +33,12 @@
 #include "db/table_cache.h"
 #include "db/version_edit.h"
 #include "db/write_batch_internal.h"
-#include "leveldb/comparator.h"
-#include "leveldb/db.h"
+
 #include "leveldb/env.h"
+#include "leveldb/iterator.h"
+#include "leveldb/table_builder.h"
+
+#include "util/logging.h"
 
 namespace leveldb {
 

--- a/db/skiplist.h
+++ b/db/skiplist.h
@@ -27,10 +27,6 @@
 //
 // ... prev vs. next pointer ordering ...
 
-#include <atomic>
-#include <cassert>
-#include <cstdlib>
-
 #include "util/arena.h"
 #include "util/random.h"
 

--- a/db/skiplist_test.cc
+++ b/db/skiplist_test.cc
@@ -4,16 +4,8 @@
 
 #include "db/skiplist.h"
 
-#include <atomic>
-#include <set>
-
-#include "gtest/gtest.h"
-#include "leveldb/env.h"
-#include "port/port.h"
-#include "port/thread_annotations.h"
-#include "util/arena.h"
+#include "port/port_stdcxx.h"
 #include "util/hash.h"
-#include "util/random.h"
 #include "util/testutil.h"
 
 namespace leveldb {

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -5,8 +5,12 @@
 #include "db/table_cache.h"
 
 #include "db/filename.h"
+
 #include "leveldb/env.h"
+#include "leveldb/iterator.h"
+#include "leveldb/options.h"
 #include "leveldb/table.h"
+
 #include "util/coding.h"
 
 namespace leveldb {

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -7,13 +7,12 @@
 #ifndef STORAGE_LEVELDB_DB_TABLE_CACHE_H_
 #define STORAGE_LEVELDB_DB_TABLE_CACHE_H_
 
-#include <cstdint>
 #include <string>
 
-#include "db/dbformat.h"
 #include "leveldb/cache.h"
+#include "leveldb/iterator.h"
+#include "leveldb/options.h"
 #include "leveldb/table.h"
-#include "port/port.h"
 
 namespace leveldb {
 

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -4,8 +4,9 @@
 
 #include "db/version_edit.h"
 
-#include "db/version_set.h"
-#include "util/coding.h"
+#include "leveldb/status.h"
+
+#include "util/logging.h"
 
 namespace leveldb {
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -5,11 +5,12 @@
 #ifndef STORAGE_LEVELDB_DB_VERSION_EDIT_H_
 #define STORAGE_LEVELDB_DB_VERSION_EDIT_H_
 
+#include "db/dbformat.h"
+#include <map>
 #include <set>
-#include <utility>
 #include <vector>
 
-#include "db/dbformat.h"
+#include "leveldb/status.h"
 
 namespace leveldb {
 

--- a/db/version_edit_test.cc
+++ b/db/version_edit_test.cc
@@ -4,6 +4,8 @@
 
 #include "db/version_edit.h"
 
+#include "leveldb/status.h"
+
 #include "gtest/gtest.h"
 
 namespace leveldb {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4,19 +4,20 @@
 
 #include "db/version_set.h"
 
-#include <algorithm>
-#include <cstdio>
-
 #include "db/filename.h"
 #include "db/log_reader.h"
 #include "db/log_writer.h"
-#include "db/memtable.h"
 #include "db/table_cache.h"
+#include <algorithm>
+
 #include "leveldb/env.h"
-#include "leveldb/table_builder.h"
+#include "leveldb/iterator.h"
+#include "leveldb/options.h"
+#include "leveldb/table.h"
+
+#include "port/port_stdcxx.h"
 #include "table/merger.h"
 #include "table/two_level_iterator.h"
-#include "util/coding.h"
 #include "util/logging.h"
 
 namespace leveldb {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -15,13 +15,12 @@
 #ifndef STORAGE_LEVELDB_DB_VERSION_SET_H_
 #define STORAGE_LEVELDB_DB_VERSION_SET_H_
 
-#include <map>
-#include <set>
-#include <vector>
-
-#include "db/dbformat.h"
 #include "db/version_edit.h"
-#include "port/port.h"
+
+#include "leveldb/options.h"
+#include "leveldb/status.h"
+
+#include "port/port_stdcxx.h"
 #include "port/thread_annotations.h"
 
 namespace leveldb {

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -4,9 +4,9 @@
 
 #include "db/version_set.h"
 
-#include "gtest/gtest.h"
-#include "util/logging.h"
-#include "util/testutil.h"
+#include <gtest/gtest_pred_impl.h>
+
+#include "version_edit.h"
 
 namespace leveldb {
 

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -13,13 +13,10 @@
 //    len: varint32
 //    data: uint8[len]
 
-#include "leveldb/write_batch.h"
-
-#include "db/dbformat.h"
 #include "db/memtable.h"
 #include "db/write_batch_internal.h"
-#include "leveldb/db.h"
-#include "util/coding.h"
+
+#include "leveldb/status.h"
 
 namespace leveldb {
 

--- a/db/write_batch_test.cc
+++ b/db/write_batch_test.cc
@@ -2,12 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "gtest/gtest.h"
 #include "db/memtable.h"
 #include "db/write_batch_internal.h"
-#include "leveldb/db.h"
-#include "leveldb/env.h"
+
+#include "leveldb/iterator.h"
+#include "leveldb/status.h"
+
 #include "util/logging.h"
+
+#include "gtest/gtest.h"
 
 namespace leveldb {
 

--- a/helpers/memenv/memenv.cc
+++ b/helpers/memenv/memenv.cc
@@ -2,18 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "helpers/memenv/memenv.h"
-
 #include <cstring>
-#include <limits>
 #include <map>
-#include <string>
-#include <vector>
 
 #include "leveldb/env.h"
-#include "leveldb/status.h"
-#include "port/port.h"
-#include "port/thread_annotations.h"
+
 #include "util/mutexlock.h"
 
 namespace leveldb {

--- a/helpers/memenv/memenv_test.cc
+++ b/helpers/memenv/memenv_test.cc
@@ -2,15 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "helpers/memenv/memenv.h"
-
-#include <string>
-#include <vector>
-
-#include "gtest/gtest.h"
 #include "db/db_impl.h"
-#include "leveldb/db.h"
-#include "leveldb/env.h"
+
+#include "leveldb/iterator.h"
+
 #include "util/testutil.h"
 
 namespace leveldb {

--- a/include/leveldb/cache.h
+++ b/include/leveldb/cache.h
@@ -19,6 +19,7 @@
 #define STORAGE_LEVELDB_INCLUDE_CACHE_H_
 
 #include <cstdint>
+#include <cstddef>
 
 #include "leveldb/export.h"
 #include "leveldb/slice.h"

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -5,12 +5,10 @@
 #ifndef STORAGE_LEVELDB_INCLUDE_DB_H_
 #define STORAGE_LEVELDB_INCLUDE_DB_H_
 
-#include <cstdint>
-#include <cstdio>
-
-#include "leveldb/export.h"
 #include "leveldb/iterator.h"
-#include "leveldb/options.h"
+
+#include "slice.h"
+#include "status.h"
 
 namespace leveldb {
 

--- a/include/leveldb/dumpfile.h
+++ b/include/leveldb/dumpfile.h
@@ -9,7 +9,6 @@
 
 #include "leveldb/env.h"
 #include "leveldb/export.h"
-#include "leveldb/status.h"
 
 namespace leveldb {
 

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -14,11 +14,8 @@
 #define STORAGE_LEVELDB_INCLUDE_ENV_H_
 
 #include <cstdarg>
-#include <cstdint>
-#include <string>
 #include <vector>
 
-#include "leveldb/export.h"
 #include "leveldb/status.h"
 
 // This workaround can be removed when leveldb::Env::DeleteFile is removed.

--- a/include/leveldb/iterator.h
+++ b/include/leveldb/iterator.h
@@ -15,6 +15,8 @@
 #ifndef STORAGE_LEVELDB_INCLUDE_ITERATOR_H_
 #define STORAGE_LEVELDB_INCLUDE_ITERATOR_H_
 
+#include <assert.h>
+
 #include "leveldb/export.h"
 #include "leveldb/slice.h"
 #include "leveldb/status.h"

--- a/include/leveldb/slice.h
+++ b/include/leveldb/slice.h
@@ -16,7 +16,6 @@
 #define STORAGE_LEVELDB_INCLUDE_SLICE_H_
 
 #include <cassert>
-#include <cstddef>
 #include <cstring>
 #include <string>
 

--- a/include/leveldb/status.h
+++ b/include/leveldb/status.h
@@ -13,10 +13,6 @@
 #ifndef STORAGE_LEVELDB_INCLUDE_STATUS_H_
 #define STORAGE_LEVELDB_INCLUDE_STATUS_H_
 
-#include <algorithm>
-#include <string>
-
-#include "leveldb/export.h"
 #include "leveldb/slice.h"
 
 namespace leveldb {

--- a/include/leveldb/table.h
+++ b/include/leveldb/table.h
@@ -10,6 +10,8 @@
 #include "leveldb/export.h"
 #include "leveldb/iterator.h"
 
+#include "status.h"
+
 namespace leveldb {
 
 class Block;

--- a/include/leveldb/table_builder.h
+++ b/include/leveldb/table_builder.h
@@ -13,9 +13,6 @@
 #ifndef STORAGE_LEVELDB_INCLUDE_TABLE_BUILDER_H_
 #define STORAGE_LEVELDB_INCLUDE_TABLE_BUILDER_H_
 
-#include <cstdint>
-
-#include "leveldb/export.h"
 #include "leveldb/options.h"
 #include "leveldb/status.h"
 

--- a/port/port.h
+++ b/port/port.h
@@ -5,13 +5,10 @@
 #ifndef STORAGE_LEVELDB_PORT_PORT_H_
 #define STORAGE_LEVELDB_PORT_PORT_H_
 
-#include <string.h>
-
 // Include the appropriate platform specific file below.  If you are
 // porting to a new platform, see "port_example.h" for documentation
 // of what the new port_<platform>.h file must provide.
 #if defined(LEVELDB_PLATFORM_POSIX) || defined(LEVELDB_PLATFORM_WINDOWS)
-#include "port/port_stdcxx.h"
 #elif defined(LEVELDB_PLATFORM_CHROMIUM)
 #include "port/port_chromium.h"
 #endif

--- a/port/port_stdcxx.h
+++ b/port/port_stdcxx.h
@@ -31,10 +31,6 @@
 
 #include <cassert>
 #include <condition_variable>  // NOLINT
-#include <cstddef>
-#include <cstdint>
-#include <mutex>  // NOLINT
-#include <string>
 
 #include "port/thread_annotations.h"
 

--- a/table/block.cc
+++ b/table/block.cc
@@ -6,14 +6,12 @@
 
 #include "table/block.h"
 
-#include <algorithm>
-#include <cstdint>
-#include <vector>
-
 #include "leveldb/comparator.h"
+#include "leveldb/iterator.h"
+#include "leveldb/status.h"
+
 #include "table/format.h"
 #include "util/coding.h"
-#include "util/logging.h"
 
 namespace leveldb {
 

--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -28,11 +28,9 @@
 
 #include "table/block_builder.h"
 
-#include <algorithm>
-#include <cassert>
-
-#include "leveldb/comparator.h"
 #include "leveldb/options.h"
+#include "leveldb/slice.h"
+
 #include "util/coding.h"
 
 namespace leveldb {

--- a/table/block_builder.h
+++ b/table/block_builder.h
@@ -6,6 +6,7 @@
 #define STORAGE_LEVELDB_TABLE_BLOCK_BUILDER_H_
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "leveldb/slice.h"

--- a/table/filter_block.h
+++ b/table/filter_block.h
@@ -9,13 +9,9 @@
 #ifndef STORAGE_LEVELDB_TABLE_FILTER_BLOCK_H_
 #define STORAGE_LEVELDB_TABLE_FILTER_BLOCK_H_
 
-#include <cstddef>
-#include <cstdint>
-#include <string>
 #include <vector>
 
 #include "leveldb/slice.h"
-#include "util/hash.h"
 
 namespace leveldb {
 

--- a/table/filter_block_test.cc
+++ b/table/filter_block_test.cc
@@ -4,12 +4,13 @@
 
 #include "table/filter_block.h"
 
-#include "gtest/gtest.h"
 #include "leveldb/filter_policy.h"
+
 #include "util/coding.h"
 #include "util/hash.h"
 #include "util/logging.h"
-#include "util/testutil.h"
+
+#include "gtest/gtest.h"
 
 namespace leveldb {
 

--- a/table/format.cc
+++ b/table/format.cc
@@ -5,8 +5,9 @@
 #include "table/format.h"
 
 #include "leveldb/env.h"
-#include "port/port.h"
-#include "table/block.h"
+#include "leveldb/options.h"
+
+#include "port/port_stdcxx.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
 

--- a/table/format.h
+++ b/table/format.h
@@ -5,12 +5,8 @@
 #ifndef STORAGE_LEVELDB_TABLE_FORMAT_H_
 #define STORAGE_LEVELDB_TABLE_FORMAT_H_
 
-#include <cstdint>
-#include <string>
-
 #include "leveldb/slice.h"
 #include "leveldb/status.h"
-#include "leveldb/table_builder.h"
 
 namespace leveldb {
 

--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -4,6 +4,8 @@
 
 #include "leveldb/iterator.h"
 
+#include "leveldb/status.h"
+
 namespace leveldb {
 
 Iterator::Iterator() {

--- a/table/iterator_wrapper.h
+++ b/table/iterator_wrapper.h
@@ -6,7 +6,7 @@
 #define STORAGE_LEVELDB_TABLE_ITERATOR_WRAPPER_H_
 
 #include "leveldb/iterator.h"
-#include "leveldb/slice.h"
+#include "leveldb/status.h"
 
 namespace leveldb {
 

--- a/table/merger.cc
+++ b/table/merger.cc
@@ -2,10 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "table/merger.h"
-
 #include "leveldb/comparator.h"
-#include "leveldb/iterator.h"
+
 #include "table/iterator_wrapper.h"
 
 namespace leveldb {

--- a/table/table.cc
+++ b/table/table.cc
@@ -8,7 +8,9 @@
 #include "leveldb/comparator.h"
 #include "leveldb/env.h"
 #include "leveldb/filter_policy.h"
+#include "leveldb/iterator.h"
 #include "leveldb/options.h"
+
 #include "table/block.h"
 #include "table/filter_block.h"
 #include "table/format.h"

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -4,12 +4,11 @@
 
 #include "leveldb/table_builder.h"
 
-#include <cassert>
-
 #include "leveldb/comparator.h"
 #include "leveldb/env.h"
 #include "leveldb/filter_policy.h"
-#include "leveldb/options.h"
+
+#include "port/port_stdcxx.h"
 #include "table/block_builder.h"
 #include "table/filter_block.h"
 #include "table/format.h"

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4,21 +4,19 @@
 
 #include "leveldb/table.h"
 
-#include <map>
-#include <string>
-
-#include "gtest/gtest.h"
-#include "db/dbformat.h"
 #include "db/memtable.h"
 #include "db/write_batch_internal.h"
+#include <cstring>
+
 #include "leveldb/db.h"
-#include "leveldb/env.h"
 #include "leveldb/iterator.h"
 #include "leveldb/table_builder.h"
+
+#include "port/port_stdcxx.h"
 #include "table/block.h"
 #include "table/block_builder.h"
 #include "table/format.h"
-#include "util/random.h"
+#include "util/logging.h"
 #include "util/testutil.h"
 
 namespace leveldb {

--- a/table/two_level_iterator.cc
+++ b/table/two_level_iterator.cc
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "table/two_level_iterator.h"
+#include "leveldb/options.h"
 
-#include "leveldb/table.h"
-#include "table/block.h"
-#include "table/format.h"
 #include "table/iterator_wrapper.h"
 
 namespace leveldb {

--- a/table/two_level_iterator.h
+++ b/table/two_level_iterator.h
@@ -6,6 +6,7 @@
 #define STORAGE_LEVELDB_TABLE_TWO_LEVEL_ITERATOR_H_
 
 #include "leveldb/iterator.h"
+#include "leveldb/slice.h"
 
 namespace leveldb {
 

--- a/util/arena.cc
+++ b/util/arena.cc
@@ -4,6 +4,10 @@
 
 #include "util/arena.h"
 
+#include <cassert>
+#include <atomic>
+#include <vector>
+
 namespace leveldb {
 
 static const int kBlockSize = 4096;

--- a/util/arena.h
+++ b/util/arena.h
@@ -5,10 +5,8 @@
 #ifndef STORAGE_LEVELDB_UTIL_ARENA_H_
 #define STORAGE_LEVELDB_UTIL_ARENA_H_
 
-#include <atomic>
 #include <cassert>
-#include <cstddef>
-#include <cstdint>
+#include <atomic>
 #include <vector>
 
 namespace leveldb {

--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "gtest/gtest.h"
 #include "leveldb/filter_policy.h"
+#include "leveldb/slice.h"
+
 #include "util/coding.h"
-#include "util/logging.h"
-#include "util/testutil.h"
+
+#include "gtest/gtest.h"
 
 namespace leveldb {
 

--- a/util/cache.cc
+++ b/util/cache.cc
@@ -4,12 +4,10 @@
 
 #include "leveldb/cache.h"
 
-#include <cassert>
-#include <cstdio>
-#include <cstdlib>
+#include <cstring>
 
-#include "port/port.h"
-#include "port/thread_annotations.h"
+#include "leveldb/slice.h"
+
 #include "util/hash.h"
 #include "util/mutexlock.h"
 

--- a/util/cache_test.cc
+++ b/util/cache_test.cc
@@ -4,10 +4,11 @@
 
 #include "leveldb/cache.h"
 
-#include <vector>
+#include "leveldb/slice.h"
+
+#include "util/coding.h"
 
 #include "gtest/gtest.h"
-#include "util/coding.h"
 
 namespace leveldb {
 

--- a/util/coding.cc
+++ b/util/coding.cc
@@ -4,6 +4,8 @@
 
 #include "util/coding.h"
 
+#include "leveldb/slice.h"
+
 namespace leveldb {
 
 void PutFixed32(std::string* dst, uint32_t value) {

--- a/util/coding.h
+++ b/util/coding.h
@@ -11,11 +11,9 @@
 #define STORAGE_LEVELDB_UTIL_CODING_H_
 
 #include <cstdint>
-#include <cstring>
 #include <string>
 
 #include "leveldb/slice.h"
-#include "port/port.h"
 
 namespace leveldb {
 

--- a/util/coding_test.cc
+++ b/util/coding_test.cc
@@ -4,9 +4,9 @@
 
 #include "util/coding.h"
 
-#include <vector>
+#include <gtest/gtest_pred_impl.h>
 
-#include "gtest/gtest.h"
+#include "leveldb/slice.h"
 
 namespace leveldb {
 

--- a/util/comparator.cc
+++ b/util/comparator.cc
@@ -4,13 +4,8 @@
 
 #include "leveldb/comparator.h"
 
-#include <algorithm>
-#include <cstdint>
-#include <string>
-#include <type_traits>
-
 #include "leveldb/slice.h"
-#include "util/logging.h"
+
 #include "util/no_destructor.h"
 
 namespace leveldb {

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -4,12 +4,7 @@
 //
 // A portable implementation of crc32c.
 
-#include "util/crc32c.h"
-
-#include <cstddef>
-#include <cstdint>
-
-#include "port/port.h"
+#include "port/port_stdcxx.h"
 #include "util/coding.h"
 
 namespace leveldb {

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -8,31 +8,14 @@
 #ifndef __Fuchsia__
 #include <sys/resource.h>
 #endif
-#include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-
 #include <atomic>
-#include <cerrno>
-#include <cstddef>
-#include <cstdint>
-#include <cstdio>
-#include <cstdlib>
 #include <cstring>
-#include <limits>
 #include <queue>
 #include <set>
-#include <string>
-#include <thread>
-#include <type_traits>
-#include <utility>
+#include <sys/stat.h>
+#include <unistd.h>
 
-#include "leveldb/env.h"
-#include "leveldb/slice.h"
-#include "leveldb/status.h"
-#include "port/port.h"
-#include "port/thread_annotations.h"
+#include "port/port_stdcxx.h"
 #include "util/env_posix_test_helper.h"
 #include "util/posix_logger.h"
 

--- a/util/env_posix_test.cc
+++ b/util/env_posix_test.cc
@@ -2,20 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include <sys/resource.h>
-#include <sys/wait.h>
-#include <unistd.h>
-
-#include <cstdio>
-#include <cstdlib>
 #include <cstring>
-#include <string>
+#include <port/port_config.h>
+#include <sys/resource.h>
 #include <unordered_set>
-#include <vector>
 
-#include "gtest/gtest.h"
-#include "leveldb/env.h"
-#include "port/port.h"
 #include "util/env_posix_test_helper.h"
 #include "util/testutil.h"
 

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "util/hash.h"
-
-#include <cstring>
-
 #include "util/coding.h"
 
 // The FALLTHROUGH_INTENDED macro can be used to annotate implicit fall-through

--- a/util/histogram.cc
+++ b/util/histogram.cc
@@ -6,8 +6,7 @@
 
 #include <cmath>
 #include <cstdio>
-
-#include "port/port.h"
+#include <string>
 
 namespace leveldb {
 

--- a/util/logging.cc
+++ b/util/logging.cc
@@ -2,14 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "util/logging.h"
-
 #include <cstdarg>
-#include <cstdio>
-#include <cstdlib>
+#include <cstdint>
 #include <limits>
+#include <string>
 
-#include "leveldb/env.h"
 #include "leveldb/slice.h"
 
 namespace leveldb {

--- a/util/logging.h
+++ b/util/logging.h
@@ -9,10 +9,7 @@
 #define STORAGE_LEVELDB_UTIL_LOGGING_H_
 
 #include <cstdint>
-#include <cstdio>
 #include <string>
-
-#include "port/port.h"
 
 namespace leveldb {
 

--- a/util/logging_test.cc
+++ b/util/logging_test.cc
@@ -4,10 +4,8 @@
 
 #include "util/logging.h"
 
-#include <limits>
-#include <string>
+#include <gtest/gtest_pred_impl.h>
 
-#include "gtest/gtest.h"
 #include "leveldb/slice.h"
 
 namespace leveldb {

--- a/util/mutexlock.h
+++ b/util/mutexlock.h
@@ -5,8 +5,7 @@
 #ifndef STORAGE_LEVELDB_UTIL_MUTEXLOCK_H_
 #define STORAGE_LEVELDB_UTIL_MUTEXLOCK_H_
 
-#include "port/port.h"
-#include "port/thread_annotations.h"
+#include "port/port_stdcxx.h"
 
 namespace leveldb {
 

--- a/util/no_destructor.h
+++ b/util/no_destructor.h
@@ -5,7 +5,6 @@
 #ifndef STORAGE_LEVELDB_UTIL_NO_DESTRUCTOR_H_
 #define STORAGE_LEVELDB_UTIL_NO_DESTRUCTOR_H_
 
-#include <type_traits>
 #include <utility>
 
 namespace leveldb {

--- a/util/no_destructor_test.cc
+++ b/util/no_destructor_test.cc
@@ -4,10 +4,6 @@
 
 #include "util/no_destructor.h"
 
-#include <cstdint>
-#include <cstdlib>
-#include <utility>
-
 #include "gtest/gtest.h"
 
 namespace leveldb {

--- a/util/posix_logger.h
+++ b/util/posix_logger.h
@@ -8,13 +8,9 @@
 #ifndef STORAGE_LEVELDB_UTIL_POSIX_LOGGER_H_
 #define STORAGE_LEVELDB_UTIL_POSIX_LOGGER_H_
 
-#include <sys/time.h>
-
-#include <cassert>
 #include <cstdarg>
-#include <cstdio>
-#include <ctime>
 #include <sstream>
+#include <sys/time.h>
 #include <thread>
 
 #include "leveldb/env.h"

--- a/util/status.cc
+++ b/util/status.cc
@@ -4,9 +4,7 @@
 
 #include "leveldb/status.h"
 
-#include <cstdio>
-
-#include "port/port.h"
+#include <cstring>
 
 namespace leveldb {
 

--- a/util/status_test.cc
+++ b/util/status_test.cc
@@ -4,10 +4,7 @@
 
 #include "leveldb/status.h"
 
-#include <utility>
-
 #include "gtest/gtest.h"
-#include "leveldb/slice.h"
 
 namespace leveldb {
 

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-#include "util/testutil.h"
-
-#include <string>
+#include "leveldb/slice.h"
 
 #include "util/random.h"
 

--- a/util/testutil.h
+++ b/util/testutil.h
@@ -5,11 +5,11 @@
 #ifndef STORAGE_LEVELDB_UTIL_TESTUTIL_H_
 #define STORAGE_LEVELDB_UTIL_TESTUTIL_H_
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "helpers/memenv/memenv.h"
+#include <gmock/gmock-matchers.h>
+
 #include "leveldb/env.h"
-#include "leveldb/slice.h"
+
 #include "util/random.h"
 
 namespace leveldb {


### PR DESCRIPTION
We applied our tool for optimizing includes to the leveldb project. It ensures for each file that header files are included if and only if they are used. As can be seen, many includes can be removed completely or moved from .h to .cc files so that in total, there are many more deletions than additions. Also, this reduces the number of lines of code after the preprocessor (in .o files) by 15.3% which results in a shorter compilation time. We computed only 114.4 sec user time on average on our machine, compared to 134.5 sec without the optimization - a reduction by 14.9%.

We remark that we applied the clang format only to the parts where we modified include directives and nowhere else. This explains why sometimes there are empty lines between the include directives now.