### PR TITLE
Fixes for C++20 support.

### DIFF
--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -144,8 +144,6 @@ struct LEVELDB_EXPORT Options {
 
 // Options that control read operations
 struct LEVELDB_EXPORT ReadOptions {
-  ReadOptions() = default;
-
   // If true, all data read from underlying storage will be
   // verified against corresponding checksums.
   bool verify_checksums = false;


### PR DESCRIPTION
Structs with user-declared constructors are no longer considered
aggregates.  Just remove the constructor declaration where applicable.

Bug: chromium:1284275