### PR TITLE
fix macro HAVE_O_CLOEXEC when O_CLOEXEC not found

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -50,7 +50,7 @@ constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 1000 : 0;
 int g_mmap_limit = kDefaultMmapLimit;
 
 // Common flags defined for all posix open operations
-#if defined(HAVE_O_CLOEXEC)
+#if HAVE_O_CLOEXEC
 constexpr const int kOpenBaseFlags = O_CLOEXEC;
 #else
 constexpr const int kOpenBaseFlags = 0;


### PR DESCRIPTION
port_config.h define HAVE_O_CLOEXEC is 0 when O_CLOEXEC not found in fcntl.h, so condition '#if defined(HAVE_O_CLOEXEC)' hit. It could be verified on centos5