### PR TITLE
Add option to limit manifest file size

### DIFF
--- a/benchmarks/db_bench.cc
+++ b/benchmarks/db_bench.cc
@@ -118,6 +118,9 @@ static bool FLAGS_use_existing_db = false;
 // If true, reuse existing log/MANIFEST files when re-opening a database.
 static bool FLAGS_reuse_logs = false;
 
+// Max size of manifest, 0 means infinite
+static uint64_t FLAGS_manifest_file_max_size = 0;
+
 // Use the db with the following name.
 static const char* FLAGS_db = nullptr;
 
@@ -771,6 +774,7 @@ class Benchmark {
     options.max_open_files = FLAGS_open_files;
     options.filter_policy = filter_policy_;
     options.reuse_logs = FLAGS_reuse_logs;
+    options.manifest_file_max_size = FLAGS_manifest_file_max_size;
     Status s = DB::Open(options, FLAGS_db, &db_);
     if (!s.ok()) {
       std::fprintf(stderr, "open error: %s\n", s.ToString().c_str());
@@ -1029,6 +1033,7 @@ int main(int argc, char** argv) {
     double d;
     int n;
     char junk;
+    uint64_t size;
     if (leveldb::Slice(argv[i]).starts_with("--benchmarks=")) {
       FLAGS_benchmarks = argv[i] + strlen("--benchmarks=");
     } else if (sscanf(argv[i], "--compression_ratio=%lf%c", &d, &junk) == 1) {
@@ -1067,6 +1072,8 @@ int main(int argc, char** argv) {
       FLAGS_bloom_bits = n;
     } else if (sscanf(argv[i], "--open_files=%d%c", &n, &junk) == 1) {
       FLAGS_open_files = n;
+    } else if (sscanf(argv[i], "--manifest_file_max_size=%llu%c", &size, &junk) == 1) {
+      FLAGS_manifest_file_max_size = size;
     } else if (strncmp(argv[i], "--db=", 5) == 0) {
       FLAGS_db = argv[i] + 5;
     } else {

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -276,6 +276,9 @@ class DBTest : public testing::Test {
       case kUncompressed:
         options.compression = kNoCompression;
         break;
+      case kManifestMaxSize:
+        options.manifest_file_max_size = 1024;
+        break;
       default:
         break;
     }
@@ -532,7 +535,7 @@ class DBTest : public testing::Test {
 
  private:
   // Sequence of option configurations to try
-  enum OptionConfig { kDefault, kReuse, kFilter, kUncompressed, kEnd };
+  enum OptionConfig { kDefault, kReuse, kFilter, kUncompressed, kManifestMaxSize, kEnd };
 
   const FilterPolicy* filter_policy_;
   int option_config_;

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -300,6 +300,7 @@ class VersionSet {
   const InternalKeyComparator icmp_;
   uint64_t next_file_number_;
   uint64_t manifest_file_number_;
+  uint64_t manifest_file_size_;
   uint64_t last_sequence_;
   uint64_t log_number_;
   uint64_t prev_log_number_;  // 0 or backing store for memtable being compacted

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -6,6 +6,7 @@
 #define STORAGE_LEVELDB_INCLUDE_OPTIONS_H_
 
 #include <cstddef>
+#include <cstdint>
 
 #include "leveldb/export.h"
 
@@ -140,6 +141,10 @@ struct LEVELDB_EXPORT Options {
   // Many applications will benefit from passing the result of
   // NewBloomFilterPolicy() here.
   const FilterPolicy* filter_policy = nullptr;
+
+  // If the size of the MANIFEST file exceeds this value,
+  // a new MANIFEST will be created.  If the value is 0, it means no limit.
+  uint64_t manifest_file_max_size = 0;
 };
 
 // Options that control read operations


### PR DESCRIPTION
After a long run, the MANIFEST file can become very large, and in extreme cases it can cause OOM on restart. So I tried adding an option to control the size of the MANIFEST file.

I noticed that someone has already tried to solve this problem (#917), but I don't know why that PR was not merged. My solution is similar in logic to that PR, but with some optimizations in the details, and adding test cases and benchmarks.

Sincerely hope that this problem can be solved as soon as possible, this problem has been bothering me and others (#899) for a long time.