### PR TITLE
Fix undefined behavior in Block::Iter and Hash.

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -99,7 +99,8 @@ class Block::Iter : public Iterator {
 
   uint32_t GetRestartPoint(uint32_t index) {
     assert(index < num_restarts_);
-    return DecodeFixed32(data_ + restarts_ + index * sizeof(uint32_t));
+    uint32_t off = DecodeFixed32(data_ + restarts_ + index * sizeof(uint32_t));
+    return std::min(off, restarts_);
   }
 
   void SeekToRestartPoint(uint32_t index) {

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -23,20 +23,21 @@ uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   // Similar to murmur hash
   const uint32_t m = 0xc6a4a793;
   const uint32_t r = 24;
-  const char* limit = data + n;
   uint32_t h = seed ^ (n * m);
+  size_t left = n;
 
   // Pick up four bytes at a time
-  while (data + 4 <= limit) {
+  while (left >= 4) {
     uint32_t w = DecodeFixed32(data);
-    data += 4;
     h += w;
     h *= m;
     h ^= (h >> 16);
+    data += 4;
+    left -= 4;
   }
 
   // Pick up remaining bytes
-  switch (limit - data) {
+  switch (left) {
     case 3:
       h += static_cast<uint8_t>(data[2]) << 16;
       FALLTHROUGH_INTENDED;


### PR DESCRIPTION
This is part 3 of my work to harden leveldb against corruption and maliciously crafted databases (see also: #1032 and #1000).

`GetRestartPoint` currently blindly trusts the restart offsets at the end of the block, does some pointer arithmetic and then checks `p >= limit` after the fact.

If a restart offset exceeds the buffer size, the mere creation of `p` is undefined behavior and the comparison of `p >= limit` becomes meaningless. This could really cause issues on 32-bit (imagine a restart offset of `2^30` overflowing the pointer).

`Hash` also potentially creates an OOB pointer with `while (data + 4 <= limit)`. 