### PR TITLE
Evict table file before archival in RepairTable.

### DIFF
--- a/db/repair.cc
+++ b/db/repair.cc
@@ -313,6 +313,8 @@ class Repairer {
     }
     delete iter;
 
+    table_cache_->Evict(t.meta.number);
+
     ArchiveFile(src);
     if (counter == 0) {
       builder->Abandon();  // Nothing to save


### PR DESCRIPTION
The `RepairTable` code currently renames the existing table file while the table cache still has an open file descriptor for it. This can cause sharing violations on windows (unless `FILE_SHARE_DELETE` is enabled on the handle).

In any case, it's probably better to avoid renaming open files in general, and in this case the open file isn't ever used again after `ArchiveFile` is called.