### PR TITLE
Add note for inactive maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 **LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.**
 
+> **Warning**   
+>
+> As of 2022, this repository is inactively maintained. We will accept the following types of changes.
+> * Bug fixes
+> * Changes needed to dependency (e.g. C++ language breaking change, breaking change in an important platforms/OS)
+
 [![ci](https://github.com/google/leveldb/actions/workflows/build.yml/badge.svg)](https://github.com/google/leveldb/actions/workflows/build.yml)
 
 Authors: Sanjay Ghemawat (sanjay@google.com) and Jeff Dean (jeff@google.com)
+
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 Authors: Sanjay Ghemawat (sanjay@google.com) and Jeff Dean (jeff@google.com)
 
-
 # Features
 
   * Keys and values are arbitrary byte arrays.


### PR DESCRIPTION
There should be a note to communicate its current development state to developers.
This adds a note on its maintenance level and the changes we will accept. 