### PR TITLE
Update db_bench.cc

### DIFF
--- a/benchmarks/db_bench.cc
+++ b/benchmarks/db_bench.cc
@@ -105,6 +105,7 @@ static int FLAGS_open_files = 0;
 
 // Bloom filter bits per key.
 // Negative means use default settings.
+// 0 means use minimum size of bloom filter.
 static int FLAGS_bloom_bits = -1;
 
 // Common key prefix length.


### PR DESCRIPTION
When studying the Bloom filter of Level DB, there was confusion about the difference between the values of 0 and -1. It would be nice to add a line of comment.