### PR TITLE
Fix EnvTest.RunMany to allow parallel execution

### DIFF
--- a/util/env_test.cc
+++ b/util/env_test.cc
@@ -96,40 +96,45 @@ TEST_F(EnvTest, RunMany) {
   struct RunState {
     port::Mutex mu;
     port::CondVar cvar{&mu};
-    int last_id = 0;
+    int run_count = 0;
   };
 
   struct Callback {
-    RunState* state_;  // Pointer to shared state.
-    const int id_;  // Order# for the execution of this callback.
+    RunState* const state_;  // Pointer to shared state.
+    bool run = false;
 
-    Callback(RunState* s, int id) : state_(s), id_(id) {}
+    Callback(RunState* s) : state_(s) {}
 
     static void Run(void* arg) {
       Callback* callback = reinterpret_cast<Callback*>(arg);
       RunState* state = callback->state_;
 
       MutexLock l(&state->mu);
-      ASSERT_EQ(state->last_id, callback->id_ - 1);
-      state->last_id = callback->id_;
+      state->run_count++;
+      callback->run = true;
       state->cvar.Signal();
     }
   };
 
   RunState state;
-  Callback callback1(&state, 1);
-  Callback callback2(&state, 2);
-  Callback callback3(&state, 3);
-  Callback callback4(&state, 4);
+  Callback callback1(&state);
+  Callback callback2(&state);
+  Callback callback3(&state);
+  Callback callback4(&state);
   env_->Schedule(&Callback::Run, &callback1);
   env_->Schedule(&Callback::Run, &callback2);
   env_->Schedule(&Callback::Run, &callback3);
   env_->Schedule(&Callback::Run, &callback4);
 
   MutexLock l(&state.mu);
-  while (state.last_id != 4) {
+  while (state.run_count != 4) {
     state.cvar.Wait();
   }
+
+  ASSERT_TRUE(callback1.run);
+  ASSERT_TRUE(callback2.run);
+  ASSERT_TRUE(callback3.run);
+  ASSERT_TRUE(callback4.run);
 }
 
 struct State {


### PR DESCRIPTION
As allowed by the documentation for Env::Schedule(), ChromiumEnv may execute functions on multiple threads and guarantees no sequencing. EnvTest.RunMany assumed that functions ran in order, is the case for the stock PosixEnv and WindowsEnv implementations. This change updates the test to not assume sequential execution.