### PR TITLE
Implement iterative directories creation

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -295,7 +295,7 @@ Status DBImpl::Recover(VersionEdit* edit, bool* save_manifest) {
   // Ignore error from CreateDir since the creation of the DB is
   // committed only when the descriptor is created, and this directory
   // may already exist from a previous failed creation attempt.
-  env_->CreateDir(dbname_);
+  env_->CreateDirIteratively(dbname_);
   assert(db_lock_ == nullptr);
   Status s = env_->LockFile(LockFileName(dbname_), &db_lock_);
   if (!s.ok()) {

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -20,6 +20,7 @@
 
 #include "leveldb/export.h"
 #include "leveldb/status.h"
+#include "util/dir_helper.h"
 
 // This workaround can be removed when leveldb::Env::DeleteFile is removed.
 #if defined(_WIN32)
@@ -112,6 +113,9 @@ class LEVELDB_EXPORT Env {
 
   // Returns true iff the named file exists.
   virtual bool FileExists(const std::string& fname) = 0;
+
+  // Returns true if specified director path exists.
+  virtual bool DirectoryExists(const std::string& dir_path) = 0;
 
   // Store in *result the names of the children of the specified directory.
   // The names are relative to "dir".
@@ -216,6 +220,9 @@ class LEVELDB_EXPORT Env {
 
   // Sleep/delay the thread for the prescribed number of micro-seconds.
   virtual void SleepForMicroseconds(int micros) = 0;
+
+  // Create folder with specified subfolders recursively
+  virtual Status CreateDirIteratively(const std::string& path) = 0;
 };
 
 // A file abstraction for reading sequentially through a file
@@ -358,6 +365,9 @@ class LEVELDB_EXPORT EnvWrapper : public Env {
   bool FileExists(const std::string& f) override {
     return target_->FileExists(f);
   }
+  bool DirectoryExists(const std::string& d) override {
+    return target_->DirectoryExists(d);
+  }
   Status GetChildren(const std::string& dir,
                      std::vector<std::string>* r) override {
     return target_->GetChildren(dir, r);
@@ -367,6 +377,9 @@ class LEVELDB_EXPORT EnvWrapper : public Env {
   }
   Status CreateDir(const std::string& d) override {
     return target_->CreateDir(d);
+  }
+  Status CreateDirIteratively(const std::string& d) override {
+    return target_->CreateDirIteratively(d);
   }
   Status RemoveDir(const std::string& d) override {
     return target_->RemoveDir(d);

--- a/util/dir_helper.h
+++ b/util/dir_helper.h
@@ -1,0 +1,41 @@
+#ifndef STORAGE_LEVELDB_UTIL_DIR_HELPER_H_
+#define STORAGE_LEVELDB_UTIL_DIR_HELPER_H_
+
+#include <cstdint>
+#include <string>
+
+namespace leveldb {
+
+inline bool IsAbsolute(const std::string& dirpath) {
+  return (
+      dirpath.size() >= 3 &&
+      (std::toupper(dirpath[0]) >= 'A' && std::toupper(dirpath[0]) <= 'Z') &&
+      dirpath[1] == ':');
+}
+
+inline bool IsDirectorySeparator(const char c) {
+  return (c == '/' || c == '\\');
+}
+
+inline std::string GetNormalizedDirectoryPath(const std::string& dirpath) {
+  std::string path = dirpath;
+  size_t remove_pos = 0;
+
+  if (!IsAbsolute(path)) {
+    remove_pos = path.find_first_not_of(".\\/");
+    if (remove_pos != std::string::npos) {
+      path.erase(0, remove_pos);
+    }
+  }
+  if (IsDirectorySeparator(path[path.size() - 1])) {
+    remove_pos = path.find_last_not_of(".\\/");
+    if (remove_pos != std::string::npos) {
+      path.erase(remove_pos + 1);
+    }
+  }
+  return path;
+}
+
+}  // namespace leveldb
+
+#endif


### PR DESCRIPTION
I am using Windows OS, so I noticed that Win32 API is not fairly enough to create a list of specified folders taken from input path. Moreover, specifying path like this: _/tmp/testdb_ creates folders specifically on a disk (F://) where project was cloned (without leading folder's separator (/), directories will be created at the same location where project's been created.
The following input paths will be interpreted as current project's location:
* "/tmp/testdb"
* "./tmp/testdb"
* "\\tmp\\testb"
* ".\\tmp\\testdb"
* "../tmp/testdb"
* "..\\..\\tmp\\testdb"
To create db folder in a specific location other than project's one, it's better to use an absolute path: "C:\\tmp\\testdb".