### PR TITLE
Check slice length in Footer::DecodeFrom()

### DIFF
--- a/table/format.cc
+++ b/table/format.cc
@@ -40,6 +40,10 @@ void Footer::EncodeTo(std::string* dst) const {
 }
 
 Status Footer::DecodeFrom(Slice* input) {
+  if (input->size() < kEncodedLength) {
+    return Status::Corruption("not an sstable (footer too short)");
+  }
+
   const char* magic_ptr = input->data() + kEncodedLength - 8;
   const uint32_t magic_lo = DecodeFixed32(magic_ptr);
   const uint32_t magic_hi = DecodeFixed32(magic_ptr + 4);


### PR DESCRIPTION
Without this check decoding the footer in Table::Open() can read uninitialized bytes from a buffer allocated on the stack if the file was unexpectedly short.

In practice this is probably fine since this function validates a magic number but MSan complains about branching on uninitialized data.