### PR TITLE
leveldb: Fix wrong string resize in Footer::EncodeTo()

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -77,7 +77,7 @@ void MemTable::Add(SequenceNumber s, ValueType type, const Slice& key,
                    const Slice& value) {
   // Format of an entry is concatenation of:
   //  key_size     : varint32 of internal_key.size()
-  //  key bytes    : char[internal_key.size()]
+  //  key bytes    : char[key.size()]
   //  tag          : uint64((sequence << 8) | type)
   //  value_size   : varint32 of value.size()
   //  value bytes  : char[value.size()]
@@ -106,7 +106,7 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s) {
   if (iter.Valid()) {
     // entry format is:
     //    klength  varint32
-    //    userkey  char[klength]
+    //    userkey  char[klength - 8]
     //    tag      uint64
     //    vlength  varint32
     //    value    char[vlength]

--- a/table/format.cc
+++ b/table/format.cc
@@ -33,11 +33,10 @@ void Footer::EncodeTo(std::string* dst) const {
   const size_t original_size = dst->size();
   metaindex_handle_.EncodeTo(dst);
   index_handle_.EncodeTo(dst);
-  dst->resize(2 * BlockHandle::kMaxEncodedLength);  // Padding
+  dst->resize(original_size + 2 * BlockHandle::kMaxEncodedLength);  // Padding
   PutFixed32(dst, static_cast<uint32_t>(kTableMagicNumber & 0xffffffffu));
   PutFixed32(dst, static_cast<uint32_t>(kTableMagicNumber >> 32));
   assert(dst->size() == original_size + kEncodedLength);
-  (void)original_size;  // Disable unused variable warning.
 }
 
 Status Footer::DecodeFrom(Slice* input) {


### PR DESCRIPTION
The resize of dst string in Footer::EncodeTo() doesn't consider the original length. Currently the string passed to Footer::EncodeTo() is empty so it doesn't expose this problem, but this could be a potential bug.