### PR TITLE
fix memory leak in kyoto cabinet benchmarks

### DIFF
--- a/benchmarks/db_bench_tree_db.cc
+++ b/benchmarks/db_bench_tree_db.cc
@@ -319,6 +319,7 @@ class Benchmark {
     if (!db_->close()) {
       std::fprintf(stderr, "close error: %s\n", db_->error().name());
     }
+    delete db_;
   }
 
   void Run() {


### PR DESCRIPTION
we should delete db_ in ~Benchmark() function