### PR TITLE
block.cc's fix

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -269,7 +269,7 @@ class Block::Iter : public Iterator {
       key_.append(p, non_shared);
       value_ = Slice(p + non_shared, value_length);
       while (restart_index_ + 1 < num_restarts_ &&
-             GetRestartPoint(restart_index_ + 1) < current_) {
+             GetRestartPoint(restart_index_ + 1) <= current_) {
         ++restart_index_;
       }
       return true;


### PR DESCRIPTION
In the leveldb/table/block.cc file, the member function ParseNextKey() of the Block::Ite class, when updating the member variable restart_index_, the last judgment condition of the while loop (GetRestartPoint(restart_index_ + 1) < current_) should be added with an equal sign.