### PR TITLE
Fix build break on system without O_CLOEXEC

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -50,11 +50,11 @@ constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 1000 : 0;
 int g_mmap_limit = kDefaultMmapLimit;
 
 // Common flags defined for all posix open operations
-#if defined(HAVE_O_CLOEXEC)
+#if HAVE_O_CLOEXEC
 constexpr const int kOpenBaseFlags = O_CLOEXEC;
 #else
 constexpr const int kOpenBaseFlags = 0;
-#endif  // defined(HAVE_O_CLOEXEC)
+#endif  // HAVE_O_CLOEXEC
 
 constexpr const size_t kWritableFileBufferSize = 65536;
 


### PR DESCRIPTION
On system without O_CLOEXEC, HAVE_O_CLOEXEC is defined as 0 in include/port/port_config.h, not undefined.  Therefore, the right way to test it is "#if HAVE_O_CLOEXEC" rather than "#if defined(...)".