### PR TITLE
refactor: Cast type explicitly

### DIFF
--- a/util/coding.cc
+++ b/util/coding.cc
@@ -56,7 +56,7 @@ char* EncodeVarint64(char* dst, uint64_t v) {
   static const int B = 128;
   uint8_t* ptr = reinterpret_cast<uint8_t*>(dst);
   while (v >= B) {
-    *(ptr++) = v | B;
+    *(ptr++) = static_cast<uint8_t>(v | B);
     v >>= 7;
   }
   *(ptr++) = static_cast<uint8_t>(v);


### PR DESCRIPTION
This change:
 - Is a pure refactor without altering the assembly code, which might be verified, for example, with the https://godbolt.org/ service.
 - Fixes warning C4244 when compiling with MSVC at production quality W3 warning level:
```
... util\coding.cc(59,18): warning C4244: '=': conversion from 'uint64_t' to 'uint8_t', possible loss of data
```