### PR TITLE
fix: correct the level of compaction output file

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -863,7 +863,7 @@ Status DBImpl::FinishCompactionOutputFile(CompactionState* compact,
     delete iter;
     if (s.ok()) {
       Log(options_.info_log, "Generated table #%llu@%d: %lld keys, %lld bytes",
-          (unsigned long long)output_number, compact->compaction->level(),
+          (unsigned long long)output_number, compact->compaction->level() + 1,
           (unsigned long long)current_entries,
           (unsigned long long)current_bytes);
     }


### PR DESCRIPTION
Current LOG prints the wrong level for compaction output files.