### PR TITLE
[jumbo] Add begin()/end() to Slice.

### DIFF
--- a/include/leveldb/slice.h
+++ b/include/leveldb/slice.h
@@ -51,6 +51,9 @@ class LEVELDB_EXPORT Slice {
   // Return true iff the length of the referenced data is zero
   bool empty() const { return size_ == 0; }
 
+  const char* begin() const { return data(); }
+  const char* end() const { return data() + size(); }
+
   // Return the ith byte in the referenced data.
   // REQUIRES: n < size()
   char operator[](size_t n) const {


### PR DESCRIPTION
This allows this type to meet the requirements of e.g. std::ranges::range, which is necessary for it to work with the std::span range constructor, or the "non-legacy" constructor for Chromium's base::span.

Bug: none