### PR TITLE
fix: windows compile fix on vs2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,12 @@ if(HAVE_CLANG_THREAD_SAFETY)
       -Werror -Wthread-safety)
 endif(HAVE_CLANG_THREAD_SAFETY)
 
+if (WIN32)
+  target_compile_options(leveldb
+    PUBLIC
+      -Wno-deprecated-declarations)
+endif(WIN32)
+
 if(HAVE_CRC32C)
   target_link_libraries(leveldb crc32c)
 endif(HAVE_CRC32C)
@@ -409,6 +415,11 @@ if(LEVELDB_BUILD_BENCHMARKS)
   set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
   set(BENCHMARK_ENABLE_EXCEPTIONS OFF CACHE BOOL "" FORCE)
   add_subdirectory("third_party/benchmark")
+  if (WIN32)
+    target_compile_options(benchmark 
+      PUBLIC 
+    -Wno-invalid-offsetof -Wno-shorten-64-to-32)
+  endif(WIN32)
 
   function(leveldb_benchmark bench_file)
     get_filename_component(bench_target_name "${bench_file}" NAME_WE)


### PR DESCRIPTION
my env settings

```
windows sdk == 10.0.22000.0
clang == 18.1.0rc
```

compile errors occurs like below

+ `deprecated-declarations`
```
db_bench.cc:1116:16: error: 'sscanf' is deprecated: This function or variable may be unsafe. Consider using sscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [-Werror,-Wdeprecated-declarations]
```

and benchmark also has some waring issue like 

```
benchmark/src/benchmark.cc:206:7: error: offset of on non-standard-layout type 'State' [-Werror,-Winvalid-offsetof]
  206 |       offsetof(State, skipped_) <= (cache_line_size - sizeof(skipped_)), "")
```