### PR TITLE
Task AB#1310794: [LevelDB] Add option to disable seek compaction

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -426,6 +426,10 @@ void leveldb_options_set_max_file_size(leveldb_options_t* opt, size_t s) {
   opt->rep.max_file_size = s;
 }
 
+void leveldb_options_set_disable_seek_autocompaction(leveldb_options_t* opt, bool v) {
+  opt->rep.disable_seek_autocompaction = v;
+}
+
 void leveldb_options_set_compression(leveldb_options_t* opt, int t) {
   opt->rep.compression = static_cast<CompressionType>(t);
 }

--- a/db/c.cc
+++ b/db/c.cc
@@ -426,7 +426,7 @@ void leveldb_options_set_max_file_size(leveldb_options_t* opt, size_t s) {
   opt->rep.max_file_size = s;
 }
 
-void leveldb_options_set_disable_seek_autocompaction(leveldb_options_t* opt, bool v) {
+void leveldb_options_set_disable_seek_autocompaction(leveldb_options_t* opt, uint8_t v) {
   opt->rep.disable_seek_autocompaction = v;
 }
 

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -189,6 +189,8 @@ LEVELDB_EXPORT void leveldb_options_set_block_restart_interval(
     leveldb_options_t*, int);
 LEVELDB_EXPORT void leveldb_options_set_max_file_size(leveldb_options_t*,
                                                       size_t);
+LEVELDB_EXPORT void leveldb_options_set_disable_seek_autocompaction(leveldb_options_t*,
+	                                                                bool);
 
 enum { leveldb_no_compression = 0, leveldb_snappy_compression = 1 };
 LEVELDB_EXPORT void leveldb_options_set_compression(leveldb_options_t*, int);

--- a/include/leveldb/c.h
+++ b/include/leveldb/c.h
@@ -190,7 +190,7 @@ LEVELDB_EXPORT void leveldb_options_set_block_restart_interval(
 LEVELDB_EXPORT void leveldb_options_set_max_file_size(leveldb_options_t*,
                                                       size_t);
 LEVELDB_EXPORT void leveldb_options_set_disable_seek_autocompaction(leveldb_options_t*,
-	                                                                bool);
+	                                                                uint8_t);
 
 enum { leveldb_no_compression = 0, leveldb_snappy_compression = 1 };
 LEVELDB_EXPORT void leveldb_options_set_compression(leveldb_options_t*, int);

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -145,6 +145,12 @@ struct LEVELDB_EXPORT Options {
   // Many applications will benefit from passing the result of
   // NewBloomFilterPolicy() here.
   const FilterPolicy* filter_policy = nullptr;
+
+  // Storage systems with low seek times (SSDs) may want to
+  // disable seek count triggered autocompaction altogether.
+  //
+  // Default: false
+  bool disable_seek_autocompaction = false;
 };
 
 // Options that control read operations


### PR DESCRIPTION
https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/1310794

Moved over the option to disable auto-compaction based on number of seeks. This is based on the two commits in leveldb-mcpe:
* https://github.com/Mojang/leveldb-mcpe/commit/470724b213620ab64c8ae68412261db9c0343870
* https://github.com/Mojang/leveldb-mcpe/commit/ad2e51ca0c26aafbbf550b37a0ea7228f9d87b0b
 
Second commit is a clean-up to get unit tests to pass.