### PR TITLE
Fix invalid pointer arithmetic in Hash

### DIFF
--- a/util/hash.cc
+++ b/util/hash.cc
@@ -27,7 +27,7 @@ uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   uint32_t h = seed ^ (n * m);
 
   // Pick up four bytes at a time
-  while (data + 4 <= limit) {
+  while (limit - data >= 4) {
     uint32_t w = DecodeFixed32(data);
     data += 4;
     h += w;


### PR DESCRIPTION
It is UB to exceed the bounds of the buffer when doing pointer arithemetic. That means the following is not a valid bounds check:

    if (start + 4 <= limit)

Because if we were at the end of the buffer, we wouldn't be allowed to add 4 anyway. Instead, this must be written as:

    if (limit - start >= 4)

Basic forms of this issue are flagged by UBSan. If building with -fsanitize=undefined, the following test trips an error:

    [ RUN      ] HASH.SignedUnsignedIssue
    .../leveldb/util/hash.cc:30:15: runtime error: applying non-zero offset 4 to null pointer
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/local/google/home/davidben/leveldb/util/hash.cc:30:15 in
    [       OK ] HASH.SignedUnsignedIssue (1 ms)