### PR TITLE
Fix C++23 compilation errors

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -874,7 +874,7 @@ class SingletonEnv {
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
-    static_assert(alignof(decltype(env_storage_)) >= alignof(EnvType),
+    static_assert(alignof(decltype(+env_storage_)) >= alignof(EnvType),
                   "env_storage_ does not meet the Env's alignment needs");
     new (&env_storage_) EnvType();
   }
@@ -892,8 +892,7 @@ class SingletonEnv {
   }
 
  private:
-  typename std::aligned_storage<sizeof(EnvType), alignof(EnvType)>::type
-      env_storage_;
+  alignas(EnvType) char env_storage_[sizeof(EnvType)];
 #if !defined(NDEBUG)
   static std::atomic<bool> env_initialized_;
 #endif  // !defined(NDEBUG)

--- a/util/env_windows.cc
+++ b/util/env_windows.cc
@@ -787,8 +787,7 @@ class SingletonEnv {
   }
 
  private:
-  typename std::aligned_storage<sizeof(EnvType), alignof(EnvType)>::type
-      env_storage_;
+  alignas(EnvType) char env_storage_[sizeof(EnvType)];
 #if !defined(NDEBUG)
   static std::atomic<bool> env_initialized_;
 #endif  // !defined(NDEBUG)

--- a/util/no_destructor.h
+++ b/util/no_destructor.h
@@ -21,7 +21,7 @@ class NoDestructor {
     static_assert(sizeof(instance_storage_) >= sizeof(InstanceType),
                   "instance_storage_ is not large enough to hold the instance");
     static_assert(
-        alignof(decltype(instance_storage_)) >= alignof(InstanceType),
+        alignof(decltype(+instance_storage_)) >= alignof(InstanceType),
         "instance_storage_ does not meet the instance's alignment requirement");
     new (&instance_storage_)
         InstanceType(std::forward<ConstructorArgTypes>(constructor_args)...);
@@ -37,8 +37,7 @@ class NoDestructor {
   }
 
  private:
-  typename std::aligned_storage<sizeof(InstanceType),
-                                alignof(InstanceType)>::type instance_storage_;
+  alignas(InstanceType) char instance_storage_[sizeof(InstanceType)];
 };
 
 }  // namespace leveldb


### PR DESCRIPTION
Remove usages of std::aligned_storage, which is deprecated. More details about the replacement in https://crbug.com/388068052.