### PR TITLE
require c++17 instead of c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif(NOT CMAKE_C_STANDARD)
 # C++ standard can be overridden when this is used as a sub-project.
 if(NOT CMAKE_CXX_STANDARD)
   # This project requires C++11.
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif(NOT CMAKE_CXX_STANDARD)


### PR DESCRIPTION
Fixes the following build issue on GCC v9:

```
In file included from leveldb/util/comparator.cc:14:
leveldb/./util/no_destructor.h: In constructor ‘leveldb::NoDestructor<InstanceType>::NoDestructor(ConstructorArgTypes&& ...)’:
leveldb/./util/no_destructor.h:24:24: error: ‘is_standard_layout_v’ is not a member of ‘std’; did you mean ‘is_standard_layout’?
   24 |     static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
      |                        ^~~~~~~~~~~~~~~~~~~~
      |                        is_standard_layout
leveldb/./util/no_destructor.h:24:70: error: expected primary-expression before ‘>’ token
   24 |     static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
      |                                                                      ^~
leveldb/./util/no_destructor.h:24:72: error: expected primary-expression before ‘)’ token
   24 |     static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
      |                                                                        ^
make[2]: *** [CMakeFiles/leveldb.dir/build.make:468: CMakeFiles/leveldb.dir/util/comparator.cc.o] Fehler 1
make[1]: *** [CMakeFiles/Makefile2:183: CMakeFiles/leveldb.dir/all] Fehler 2
```

This is a [C++17 feature](https://en.cppreference.com/w/cpp/types/is_standard_layout).

Note: I won't sign Google CLA.