### PR TITLE
build: Allow compiling with -Wunsafe-buffer-usage

### DIFF
--- a/benchmarks/db_bench.cc
+++ b/benchmarks/db_bench.cc
@@ -21,6 +21,8 @@
 #include "util/random.h"
 #include "util/testutil.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 // Comma-separated list of operations to run in the specified order
 //   Actual benchmarks:
 //      fillseq       -- write N values in sequential key order in async mode
@@ -1136,3 +1138,5 @@ int main(int argc, char** argv) {
   benchmark.Run();
   return 0;
 }
+
+#pragma clang unsafe_buffer_usage end

--- a/benchmarks/db_bench_sqlite3.cc
+++ b/benchmarks/db_bench_sqlite3.cc
@@ -11,6 +11,8 @@
 #include "util/random.h"
 #include "util/testutil.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 // Comma-separated list of operations to run in the specified order
 //   Actual benchmarks:
 //
@@ -724,3 +726,5 @@ int main(int argc, char** argv) {
   benchmark.Run();
   return 0;
 }
+
+#pragma clang unsafe_buffer_usage end

--- a/db/c.cc
+++ b/db/c.cc
@@ -44,6 +44,8 @@ using leveldb::WritableFile;
 using leveldb::WriteBatch;
 using leveldb::WriteOptions;
 
+#pragma clang unsafe_buffer_usage begin
+
 extern "C" {
 
 struct leveldb_t {
@@ -563,3 +565,5 @@ int leveldb_major_version() { return kMajorVersion; }
 int leveldb_minor_version() { return kMinorVersion; }
 
 }  // end extern "C"
+
+#pragma clang unsafe_buffer_usage end

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -159,19 +159,23 @@ class CorruptionTest : public testing::Test {
   int Property(const std::string& name) {
     std::string property;
     int result;
+#pragma clang unsafe_buffer_usage begin
     if (db_->GetProperty(name, &property) &&
         sscanf(property.c_str(), "%d", &result) == 1) {
       return result;
     } else {
       return -1;
     }
+#pragma clang unsafe_buffer_usage end
   }
 
   // Return the ith key
   Slice Key(int i, std::string* storage) {
     char buf[100];
     std::snprintf(buf, sizeof(buf), "%016d", i);
+#pragma clang unsafe_buffer_usage begin
     storage->assign(buf, strlen(buf));
+#pragma clang unsafe_buffer_usage end
     return Slice(*storage);
   }
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -35,6 +35,8 @@
 #include "util/logging.h"
 #include "util/mutexlock.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 const int kNumNonTableCacheFiles = 10;
@@ -1576,3 +1578,6 @@ Status DestroyDB(const std::string& dbname, const Options& options) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
+

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -24,6 +24,8 @@
 #include "util/mutexlock.h"
 #include "util/testutil.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 static std::string RandomString(Random* rnd, int len) {
@@ -2358,3 +2360,5 @@ TEST_F(DBTest, Randomized) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -10,6 +10,8 @@
 #include "port/port.h"
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 static uint64_t PackSequenceAndType(uint64_t seq, ValueType t) {
@@ -134,3 +136,5 @@ LookupKey::LookupKey(const Slice& user_key, SequenceNumber s) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -17,6 +17,8 @@
 #include "util/coding.h"
 #include "util/logging.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 // Grouping of constants.  We may want to make some of these
@@ -220,5 +222,7 @@ inline LookupKey::~LookupKey() {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
 
 #endif  // STORAGE_LEVELDB_DB_DBFORMAT_H_

--- a/db/dbformat_test.cc
+++ b/db/dbformat_test.cc
@@ -7,6 +7,8 @@
 #include "gtest/gtest.h"
 #include "util/logging.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 static std::string IKey(const std::string& user_key, uint64_t seq,
@@ -126,3 +128,5 @@ TEST(FormatTest, InternalKeyDebugString) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/dumpfile.cc
+++ b/db/dumpfile.cc
@@ -19,6 +19,8 @@
 #include "leveldb/write_batch.h"
 #include "util/logging.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 namespace {
@@ -230,3 +232,5 @@ Status DumpFile(Env* env, const std::string& fname, WritableFile* dst) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/filename.cc
+++ b/db/filename.cc
@@ -20,8 +20,10 @@ Status WriteStringToFileSync(Env* env, const Slice& data,
 static std::string MakeFileName(const std::string& dbname, uint64_t number,
                                 const char* suffix) {
   char buf[100];
+#pragma clang unsafe_buffer_usage begin
   std::snprintf(buf, sizeof(buf), "/%06llu.%s",
                 static_cast<unsigned long long>(number), suffix);
+#pragma clang unsafe_buffer_usage end
   return dbname + buf;
 }
 

--- a/db/filename_test.cc
+++ b/db/filename_test.cc
@@ -9,6 +9,8 @@
 #include "port/port.h"
 #include "util/logging.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 TEST(FileNameTest, Parse) {
@@ -125,3 +127,5 @@ TEST(FileNameTest, Construction) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/leveldbutil.cc
+++ b/db/leveldbutil.cc
@@ -8,6 +8,8 @@
 #include "leveldb/env.h"
 #include "leveldb/status.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 namespace {
 
@@ -62,3 +64,5 @@ int main(int argc, char** argv) {
   }
   return (ok ? 0 : 1);
 }
+
+#pragma clang unsafe_buffer_usage end

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -10,6 +10,8 @@
 #include "util/coding.h"
 #include "util/crc32c.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 namespace log {
 
@@ -272,3 +274,5 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result) {
 
 }  // namespace log
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -10,6 +10,8 @@
 #include "util/crc32c.h"
 #include "util/random.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 namespace log {
 
@@ -556,3 +558,5 @@ TEST_F(LogTest, ReadPastEnd) { CheckOffsetPastEndReturnsNoRecords(5); }
 
 }  // namespace log
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -10,6 +10,8 @@
 #include "util/coding.h"
 #include "util/crc32c.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 namespace log {
 
@@ -109,3 +111,5 @@ Status Writer::EmitPhysicalRecord(RecordType t, const char* ptr,
 
 }  // namespace log
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -9,6 +9,8 @@
 #include "leveldb/iterator.h"
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 static Slice GetLengthPrefixedSlice(const char* data) {
@@ -136,3 +138,5 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -38,6 +38,8 @@
 #include "leveldb/db.h"
 #include "leveldb/env.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 namespace {
@@ -449,3 +451,5 @@ Status RepairDB(const std::string& dbname, const Options& options) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/skiplist.h
+++ b/db/skiplist.h
@@ -34,6 +34,8 @@
 #include "util/arena.h"
 #include "util/random.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 template <typename Key, class Comparator>
@@ -376,5 +378,7 @@ bool SkipList<Key, Comparator>::Contains(const Key& key) const {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
 
 #endif  // STORAGE_LEVELDB_DB_SKIPLIST_H_

--- a/db/skiplist_test.cc
+++ b/db/skiplist_test.cc
@@ -16,6 +16,8 @@
 #include "util/random.h"
 #include "util/testutil.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 typedef uint64_t Key;
@@ -366,3 +368,5 @@ TEST(SkipTest, Concurrent4) { RunConcurrent(4); }
 TEST(SkipTest, Concurrent5) { RunConcurrent(5); }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -19,6 +19,8 @@
 #include "util/coding.h"
 #include "util/logging.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 static size_t TargetFileSize(const Options* options) {
@@ -1567,3 +1569,5 @@ void Compaction::ReleaseInputs() {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -24,6 +24,8 @@
 #include "port/port.h"
 #include "port/thread_annotations.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 namespace log {
@@ -389,5 +391,7 @@ class Compaction {
 };
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
 
 #endif  // STORAGE_LEVELDB_DB_VERSION_SET_H_

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -21,6 +21,8 @@
 #include "leveldb/db.h"
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 // WriteBatch header has an 8-byte sequence number followed by a 4-byte count.
@@ -148,3 +150,5 @@ void WriteBatchInternal::Append(WriteBatch* dst, const WriteBatch* src) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/helpers/memenv/memenv.cc
+++ b/helpers/memenv/memenv.cc
@@ -16,6 +16,8 @@
 #include "port/thread_annotations.h"
 #include "util/mutexlock.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 namespace {
@@ -388,3 +390,5 @@ class InMemoryEnv : public EnvWrapper {
 Env* NewMemEnv(Env* base_env) { return new InMemoryEnv(base_env); }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/helpers/memenv/memenv_test.cc
+++ b/helpers/memenv/memenv_test.cc
@@ -13,6 +13,8 @@
 #include "leveldb/env.h"
 #include "util/testutil.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 class MemEnvTest : public testing::Test {
@@ -257,3 +259,5 @@ TEST_F(MemEnvTest, DBTest) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/include/leveldb/slice.h
+++ b/include/leveldb/slice.h
@@ -22,6 +22,8 @@
 
 #include "leveldb/export.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 class LEVELDB_EXPORT Slice {
@@ -110,5 +112,7 @@ inline int Slice::compare(const Slice& b) const {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
 
 #endif  // STORAGE_LEVELDB_INCLUDE_SLICE_H_

--- a/include/leveldb/status.h
+++ b/include/leveldb/status.h
@@ -19,6 +19,8 @@
 #include "leveldb/export.h"
 #include "leveldb/slice.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 class LEVELDB_EXPORT Status {
@@ -118,5 +120,7 @@ inline Status& Status::operator=(Status&& rhs) noexcept {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
 
 #endif  // STORAGE_LEVELDB_INCLUDE_STATUS_H_

--- a/table/block.cc
+++ b/table/block.cc
@@ -15,6 +15,8 @@
 #include "util/coding.h"
 #include "util/logging.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 inline uint32_t Block::NumRestarts() const {
@@ -290,3 +292,5 @@ Iterator* Block::NewIterator(const Comparator* comparator) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -35,6 +35,8 @@
 #include "leveldb/options.h"
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 BlockBuilder::BlockBuilder(const Options* options)
@@ -105,3 +107,5 @@ void BlockBuilder::Add(const Slice& key, const Slice& value) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/table/filter_block.cc
+++ b/table/filter_block.cc
@@ -7,6 +7,8 @@
 #include "leveldb/filter_policy.h"
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 // See doc/table_format.md for an explanation of the filter block format.
@@ -104,3 +106,5 @@ bool FilterBlockReader::KeyMayMatch(uint64_t block_offset, const Slice& key) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/table/filter_block_test.cc
+++ b/table/filter_block_test.cc
@@ -11,6 +11,8 @@
 #include "util/logging.h"
 #include "util/testutil.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 // For testing: emit an array with one hash value per key
@@ -120,3 +122,5 @@ TEST_F(FilterBlockTest, MultiChunk) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/table/format.cc
+++ b/table/format.cc
@@ -11,6 +11,8 @@
 #include "util/coding.h"
 #include "util/crc32c.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 void BlockHandle::EncodeTo(std::string* dst) const {
@@ -162,3 +164,5 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/table/merger.cc
+++ b/table/merger.cc
@@ -8,6 +8,8 @@
 #include "leveldb/iterator.h"
 #include "table/iterator_wrapper.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 namespace {
@@ -189,3 +191,5 @@ Iterator* NewMergingIterator(const Comparator* comparator, Iterator** children,
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/table/table.cc
+++ b/table/table.cc
@@ -15,6 +15,8 @@
 #include "table/two_level_iterator.h"
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 struct Table::Rep {
@@ -269,3 +271,5 @@ uint64_t Table::ApproximateOffsetOf(const Slice& key) const {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -16,6 +16,8 @@
 #include "util/coding.h"
 #include "util/crc32c.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 struct TableBuilder::Rep {
@@ -278,3 +280,5 @@ uint64_t TableBuilder::NumEntries() const { return rep_->num_entries; }
 uint64_t TableBuilder::FileSize() const { return rep_->offset; }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -22,6 +22,8 @@
 #include "util/random.h"
 #include "util/testutil.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 // Return reverse of "key".
@@ -840,3 +842,5 @@ TEST_P(CompressionTableTest, ApproximateOffsetOfCompressed) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/arena.cc
+++ b/util/arena.cc
@@ -4,6 +4,8 @@
 
 #include "util/arena.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 static const int kBlockSize = 4096;
@@ -64,3 +66,5 @@ char* Arena::AllocateNewBlock(size_t block_bytes) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/arena.h
+++ b/util/arena.h
@@ -11,6 +11,8 @@
 #include <cstdint>
 #include <vector>
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 class Arena {
@@ -67,5 +69,7 @@ inline char* Arena::Allocate(size_t bytes) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
 
 #endif  // STORAGE_LEVELDB_UTIL_ARENA_H_

--- a/util/arena_test.cc
+++ b/util/arena_test.cc
@@ -7,6 +7,8 @@
 #include "gtest/gtest.h"
 #include "util/random.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 TEST(ArenaTest, Empty) { Arena arena; }
@@ -59,3 +61,5 @@ TEST(ArenaTest, Simple) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/bloom.cc
+++ b/util/bloom.cc
@@ -7,6 +7,8 @@
 #include "leveldb/slice.h"
 #include "util/hash.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 namespace {
@@ -90,3 +92,5 @@ const FilterPolicy* NewBloomFilterPolicy(int bits_per_key) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/cache.cc
+++ b/util/cache.cc
@@ -13,6 +13,8 @@
 #include "util/hash.h"
 #include "util/mutexlock.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 Cache::~Cache() {}
@@ -399,3 +401,5 @@ class ShardedLRUCache : public Cache {
 Cache* NewLRUCache(size_t capacity) { return new ShardedLRUCache(capacity); }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/coding.cc
+++ b/util/coding.cc
@@ -4,6 +4,8 @@
 
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 void PutFixed32(std::string* dst, uint32_t value) {
@@ -154,3 +156,5 @@ bool GetLengthPrefixedSlice(Slice* input, Slice* result) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/coding.h
+++ b/util/coding.h
@@ -17,6 +17,8 @@
 #include "leveldb/slice.h"
 #include "port/port.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 // Standard Put... routines append to a string
@@ -118,5 +120,7 @@ inline const char* GetVarint32Ptr(const char* p, const char* limit,
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
 
 #endif  // STORAGE_LEVELDB_UTIL_CODING_H_

--- a/util/coding_test.cc
+++ b/util/coding_test.cc
@@ -8,6 +8,8 @@
 
 #include "gtest/gtest.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 TEST(Coding, Fixed32) {
@@ -191,3 +193,5 @@ TEST(Coding, Strings) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -12,6 +12,8 @@
 #include "port/port.h"
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 namespace crc32c {
 
@@ -378,3 +380,5 @@ uint32_t Extend(uint32_t crc, const char* data, size_t n) {
 
 }  // namespace crc32c
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/crc32c_test.cc
+++ b/util/crc32c_test.cc
@@ -6,6 +6,8 @@
 
 #include "gtest/gtest.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 namespace crc32c {
 
@@ -54,3 +56,5 @@ TEST(CRC, Mask) {
 
 }  // namespace crc32c
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -36,6 +36,8 @@
 #include "util/env_posix_test_helper.h"
 #include "util/posix_logger.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 namespace {
@@ -927,3 +929,5 @@ Env* Env::Default() {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/env_posix_test.cc
+++ b/util/env_posix_test.cc
@@ -19,6 +19,8 @@
 #include "util/env_posix_test_helper.h"
 #include "util/testutil.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 #if HAVE_O_CLOEXEC
 
 namespace {
@@ -351,3 +353,5 @@ int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+#pragma clang unsafe_buffer_usage end

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -8,6 +8,8 @@
 
 #include "util/coding.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 // The FALLTHROUGH_INTENDED macro can be used to annotate implicit fall-through
 // between switch labels. The real definition should be provided externally.
 // This one is a fallback version for unsupported compilers.
@@ -53,3 +55,5 @@ uint32_t Hash(const char* data, size_t n, uint32_t seed) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/histogram.cc
+++ b/util/histogram.cc
@@ -9,6 +9,8 @@
 
 #include "port/port.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 const double Histogram::kBucketLimit[kNumBuckets] = {
@@ -270,3 +272,5 @@ std::string Histogram::ToString() const {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/logging.cc
+++ b/util/logging.cc
@@ -12,6 +12,8 @@
 #include "leveldb/env.h"
 #include "leveldb/slice.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 void AppendNumberTo(std::string* str, uint64_t num) {
@@ -80,3 +82,5 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/posix_logger.h
+++ b/util/posix_logger.h
@@ -19,6 +19,8 @@
 
 #include "leveldb/env.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 class PosixLogger final : public Logger {
@@ -126,5 +128,7 @@ class PosixLogger final : public Logger {
 };
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end
 
 #endif  // STORAGE_LEVELDB_UTIL_POSIX_LOGGER_H_

--- a/util/status.cc
+++ b/util/status.cc
@@ -8,6 +8,8 @@
 
 #include "port/port.h"
 
+#pragma clang unsafe_buffer_usage begin
+
 namespace leveldb {
 
 const char* Status::CopyState(const char* state) {
@@ -75,3 +77,5 @@ std::string Status::ToString() const {
 }
 
 }  // namespace leveldb
+
+#pragma clang unsafe_buffer_usage end

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -26,7 +26,9 @@ std::string RandomKey(Random* rnd, int len) {
                                     'd',  'e',  '\xfd', '\xfe', '\xff'};
   std::string result;
   for (int i = 0; i < len; i++) {
+#pragma clang unsafe_buffer_usage begin
     result += kTestChars[rnd->Uniform(sizeof(kTestChars))];
+#pragma clang unsafe_buffer_usage end
   }
   return result;
 }


### PR DESCRIPTION
Just opt out all of the files with errors via the pragma unsafe_buffer_usage.