### PR TITLE
Reland changes accidentally reverted in 302786e

### DIFF
--- a/include/leveldb/slice.h
+++ b/include/leveldb/slice.h
@@ -51,6 +51,9 @@ class LEVELDB_EXPORT Slice {
   // Return true iff the length of the referenced data is zero
   bool empty() const { return size_ == 0; }
 
+  const char* begin() const { return data(); }
+  const char* end() const { return data() + size(); }
+
   // Return the ith byte in the referenced data.
   // REQUIRES: n < size()
   char operator[](size_t n) const {

--- a/util/hash.cc
+++ b/util/hash.cc
@@ -27,7 +27,7 @@ uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   uint32_t h = seed ^ (n * m);
 
   // Pick up four bytes at a time
-  while (data + 4 <= limit) {
+  while (limit - data >= 4) {
     uint32_t w = DecodeFixed32(data);
     data += 4;
     h += w;


### PR DESCRIPTION
These changes
  1) 2cc36eb - "[jumbo] Add begin()/end() to Slice."
  2) 578eeb7 - "Fix invalid pointer arithmetic in Hash (#1222)"


were committed in the public repository but never got imported to the internal Google repository.
Later, cl/713346733 landed in the internal repo. When tooling published the internal change as 302786e ("Fix C++23 compilation errors in leveldb"), it accidentally reverted commits (1) and (2).

This change re-commits a bundled version of (1) and (2) in the public repo. This will then be imported to the private repo, leaving the 2 in sync.