### PR TITLE
Fix C++ Compatibility: Replace C++17 std::is_standard_layout_v to std::is_standard_layout<T>::value

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -874,7 +874,7 @@ class SingletonEnv {
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
-    static_assert(std::is_standard_layout_v<SingletonEnv<EnvType>>);
+    static_assert(std::is_standard_layout<SingletonEnv<EnvType>>::value);
     static_assert(
         offsetof(SingletonEnv<EnvType>, env_storage_) % alignof(EnvType) == 0,
         "env_storage_ does not meet the Env's alignment needs");

--- a/util/no_destructor.h
+++ b/util/no_destructor.h
@@ -21,7 +21,7 @@ class NoDestructor {
   explicit NoDestructor(ConstructorArgTypes&&... constructor_args) {
     static_assert(sizeof(instance_storage_) >= sizeof(InstanceType),
                   "instance_storage_ is not large enough to hold the instance");
-    static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
+    static_assert(std::is_standard_layout<NoDestructor<InstanceType>>::value);
     static_assert(
         offsetof(NoDestructor, instance_storage_) % alignof(InstanceType) == 0,
         "instance_storage_ does not meet the instance's alignment requirement");


### PR DESCRIPTION
C++11 Compatibility:
Replaced the C++17 variable template alias std::is_standard_layout_v with the C++11 compatible form std::is_standard_layout<T>::value in static assertions (e.g., in no_destructor.h and within env_posix.cc). This change preserves the compile-time checks while allowing builds that are limited to C++11.