### PR TITLE
cmake: warning flags should be private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ endif(BUILD_SHARED_LIBS)
 
 if(HAVE_CLANG_THREAD_SAFETY)
   target_compile_options(leveldb
-    PUBLIC
+    PRIVATE
       -Werror -Wthread-safety)
 endif(HAVE_CLANG_THREAD_SAFETY)
 


### PR DESCRIPTION
Do not set -Werror for all the code that links this library.