### PR TITLE
win32: fix -Wmissing-field-initializers warnings

### DIFF
--- a/util/env_windows.cc
+++ b/util/env_windows.cc
@@ -208,7 +208,7 @@ class WindowsRandomAccessFile : public RandomAccessFile {
   Status Read(uint64_t offset, size_t n, Slice* result,
               char* scratch) const override {
     DWORD bytes_read = 0;
-    OVERLAPPED overlapped = {0};
+    OVERLAPPED overlapped = {};
 
     overlapped.OffsetHigh = static_cast<DWORD>(offset >> 32);
     overlapped.Offset = static_cast<DWORD>(offset);


### PR DESCRIPTION
Reviving https://github.com/google/leveldb/pull/1053