### PR TITLE
Increase maximum read-only mmap()s used from 1000 to 4096 on 64-bit systems

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -43,8 +43,8 @@ namespace {
 // Set by EnvPosixTestHelper::SetReadOnlyMMapLimit() and MaxOpenFiles().
 int g_open_read_only_file_limit = -1;
 
-// Up to 1000 mmap regions for 64-bit binaries; none for 32-bit.
-constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 1000 : 0;
+// Up to 4096 mmap regions for 64-bit binaries; none for 32-bit.
+constexpr const int kDefaultMmapLimit = (sizeof(void*) >= 8) ? 4096 : 0;
 
 // Can be set using EnvPosixTestHelper::SetReadOnlyMMapLimit().
 int g_mmap_limit = kDefaultMmapLimit;


### PR DESCRIPTION
Cherry-picking https://github.com/bitcoin-core/leveldb-subtree/commit/92ae82c78f225de84040c51e07fd0b4a61caed99 and revives https://github.com/google/leveldb/pull/613