### PR TITLE
doc: fix the missing documentation

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -176,7 +176,7 @@ class PosixSequentialFile final : public SequentialFile {
 class PosixRandomAccessFile final : public RandomAccessFile {
  public:
   // The new instance takes ownership of |fd|. |fd_limiter| must outlive this
-  // instance, and will be used to determine if .
+  // instance, and will be used to determine if the file will be opened on every read.
   PosixRandomAccessFile(std::string filename, int fd, Limiter* fd_limiter)
       : has_permanent_fd_(fd_limiter->Acquire()),
         fd_(has_permanent_fd_ ? fd : -1),


### PR DESCRIPTION
**Brief**: Fix the missing half-sentence documentation in `env_posix.cc`. I found it while reading the code.