### PR TITLE
Reduce the number of scope expansions during overlapped file detection in Version::GetOverlappingInputs

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -526,7 +526,8 @@ void Version::GetOverlappingInputs(int level, const InternalKey* begin,
           user_begin = file_start;
           inputs->clear();
           i = 0;
-        } else if (end != nullptr &&
+        } 
+        if (end != nullptr &&
                    user_cmp->Compare(file_limit, user_end) > 0) {
           user_end = file_limit;
           inputs->clear();


### PR DESCRIPTION
```
if (begin != nullptr && user_cmp->Compare(file_start, user_begin) < 0) {
  user_begin = file_start;
  inputs->clear();
  i = 0;
 } else if (end != nullptr &&
           user_cmp->Compare(file_limit, user_end) > 0) {
  user_end = file_limit;
  inputs->clear();
  i = 0;
}
```
If the range of user_begin and user_end is `[c, d]` while the range of file_start and file_limit is `[a, g]`, this would result in two scope expansions:  first expanding user_begin and user_end to [a, d], and then further expanding them to [a, g], thereby increasing the number of loop iterations.

Removing this `else` clause would allow completing the scope expansion in a single step by directly adjusting user_begin and user_end to [a, g].