### PR TITLE
Fix clang thread-safety-pointer warnings

### DIFF
--- a/util/cache.cc
+++ b/util/cache.cc
@@ -172,8 +172,8 @@ class LRUCache {
  private:
   void LRU_Remove(LRUHandle* e);
   void LRU_Append(LRUHandle* list, LRUHandle* e);
-  void Ref(LRUHandle* e);
-  void Unref(LRUHandle* e);
+  void Ref(LRUHandle* e) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void Unref(LRUHandle* e) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   bool FinishErase(LRUHandle* e) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // Initialized before use.


### PR DESCRIPTION
Clang's `-Wthread-safety-pointer` warnings will become part of `-Wthread-safety` in some future release. Add missing annotations for functions that pass the address of guarded members. No functional change. Fixes the following warnings:

```bash
util/cache.cc:220:17: warning: passing pointer to variable 'in_use_' requires holding mutex 'mutex_' [-Wthread-safety-pointer]
  220 |     LRU_Append(&in_use_, e);
      |                 ^
util/cache.cc:235:17: warning: passing pointer to variable 'lru_' requires holding mutex 'mutex_' [-Wthread-safety-pointer]
  235 |     LRU_Append(&lru_, e);
```