### PR TITLE
Fix C++11 compatibility: use std::is_standard_layout<T>::value

### DIFF
--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -874,7 +874,8 @@ class SingletonEnv {
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
-    static_assert(std::is_standard_layout_v<SingletonEnv<EnvType>>);
+    static_assert(std::is_standard_layout<SingletonEnv<EnvType>>::value,
+                  "SingletonEnv<EnvType> must have standard layout");
     static_assert(
         offsetof(SingletonEnv<EnvType>, env_storage_) % alignof(EnvType) == 0,
         "env_storage_ does not meet the Env's alignment needs");

--- a/util/no_destructor.h
+++ b/util/no_destructor.h
@@ -21,7 +21,8 @@ class NoDestructor {
   explicit NoDestructor(ConstructorArgTypes&&... constructor_args) {
     static_assert(sizeof(instance_storage_) >= sizeof(InstanceType),
                   "instance_storage_ is not large enough to hold the instance");
-    static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
+    static_assert(std::is_standard_layout<NoDestructor<InstanceType>>::value,
+                  "NoDestructor<InstanceType> must have standard layout");
     static_assert(
         offsetof(NoDestructor, instance_storage_) % alignof(InstanceType) == 0,
         "instance_storage_ does not meet the instance's alignment requirement");


### PR DESCRIPTION
Please update static assertions to use the older `std::is_standard_layout<T>::value` syntax instead of the newer `std::is_standard_layout_v<T>`. 
```
In file included from leveldb/util/comparator.cc:14:
leveldb/./util/no_destructor.h: In constructor ‘leveldb::NoDestructor<InstanceType>::NoDestructor(ConstructorArgTypes&& ...)’:
leveldb/./util/no_destructor.h:24:24: error: ‘is_standard_layout_v’ is not a member of ‘std’; did you mean ‘is_standard_layout’?
   24 |     static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
      |                        ^~~~~~~~~~~~~~~~~~~~
      |                        is_standard_layout
leveldb/./util/no_destructor.h:24:70: error: expected primary-expression before ‘>’ token
   24 |     static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
      |                                                                      ^~
leveldb/./util/no_destructor.h:24:72: error: expected primary-expression before ‘)’ token
   24 |     static_assert(std::is_standard_layout_v<NoDestructor<InstanceType>>);
      |                                                                        ^
make[2]: *** [CMakeFiles/leveldb.dir/build.make:468: CMakeFiles/leveldb.dir/util/comparator.cc.o] Fehler 1
make[1]: *** [CMakeFiles/Makefile2:183: CMakeFiles/leveldb.dir/all] Fehler 2
```