### PR TITLE
Upgrade checkout action from v2 to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         matrix.optimized && 'RelWithDebInfo' || 'Debug') }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       with:
         submodules: true
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the checkout action. Checkout v5 and onwards use node 24.