### PR TITLE
Fix CompactRange hang

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -646,7 +646,8 @@ Status DBImpl::TEST_CompactMemTable() {
   if (s.ok()) {
     // Wait until the compaction completes
     MutexLock l(&mutex_);
-    while (imm_ != nullptr && bg_error_.ok()) {
+    while (imm_ != nullptr && bg_error_.ok() &&
+           !shutting_down_.load(std::memory_order_acquire)) {
       background_work_finished_signal_.Wait();
     }
     if (imm_ != nullptr) {


### PR DESCRIPTION
This PR ensures that CompactRange doesn't get stuck on waiting on background_work_finished_signal_ during shutdown, because while background_work_finished_signal_ may be signal, CompactMemTable() will never actually run.