### PR TITLE
Fix integer overflow in ReadBlock block size calculation

### DIFF
--- a/table/format.cc
+++ b/table/format.cc
@@ -75,6 +75,9 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
   // Read the block contents as well as the type/crc footer.
   // See table_builder.cc for the code that built this structure.
   size_t n = static_cast<size_t>(handle.size());
+  if (n + kBlockTrailerSize < n) {
+    return Status::Corruption("bad block length");
+  }
   char* buf = new char[n + kBlockTrailerSize];
   Slice contents;
   Status s = file->Read(handle.offset(), n + kBlockTrailerSize, &contents, buf);


### PR DESCRIPTION
## Summary
- Fix integer overflow in `ReadBlock()` where `n + kBlockTrailerSize` wraps when `handle.size()` is near `SIZE_MAX`, bypassing the truncation check and causing an out-of-bounds heap read at `data[n]`

## Details
`BlockHandle::size_` is decoded from varint64 with no upper-bound validation. When the size is close to `SIZE_MAX`, the addition `n + kBlockTrailerSize` (where `kBlockTrailerSize` is 5) wraps to a small value. This causes:

1. An undersized allocation (`new char[wrapped_value]`)
2. The size check at line 85 passes (compares against the same wrapped value)
3. `data[n]` reads out of bounds, crashing the process

The fix adds an overflow check before the allocation.