### PR TITLE
Fix memory safety bugs in block reading and decompression

### DIFF
--- a/port/port_stdcxx.h
+++ b/port/port_stdcxx.h
@@ -164,7 +164,9 @@ inline bool Zstd_GetUncompressedLength(const char* input, size_t length,
                                        size_t* result) {
 #if HAVE_ZSTD
   size_t size = ZSTD_getFrameContentSize(input, length);
-  if (size == 0) return false;
+  if (size == 0 || size == ZSTD_CONTENTSIZE_UNKNOWN ||
+      size == ZSTD_CONTENTSIZE_ERROR)
+    return false;
   *result = size;
   return true;
 #else

--- a/table/block.cc
+++ b/table/block.cc
@@ -68,7 +68,8 @@ static inline const char* DecodeEntry(const char* p, const char* limit,
     if ((p = GetVarint32Ptr(p, limit, value_length)) == nullptr) return nullptr;
   }
 
-  if (static_cast<uint32_t>(limit - p) < (*non_shared + *value_length)) {
+  if (static_cast<uint32_t>(limit - p) < *non_shared ||
+      static_cast<uint32_t>(limit - p) - *non_shared < *value_length) {
     return nullptr;
   }
   return p;

--- a/table/format.cc
+++ b/table/format.cc
@@ -4,6 +4,8 @@
 
 #include "table/format.h"
 
+#include <limits>
+
 #include "leveldb/env.h"
 #include "leveldb/options.h"
 #include "port/port.h"
@@ -74,6 +76,11 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
 
   // Read the block contents as well as the type/crc footer.
   // See table_builder.cc for the code that built this structure.
+  if (handle.size() >
+      static_cast<uint64_t>(std::numeric_limits<size_t>::max()) -
+          kBlockTrailerSize) {
+    return Status::Corruption("block size overflow");
+  }
   size_t n = static_cast<size_t>(handle.size());
   char* buf = new char[n + kBlockTrailerSize];
   Slice contents;


### PR DESCRIPTION
## Summary

Fix three security-relevant bugs that can be triggered by maliciously crafted SST files:

- **ReadBlock integer overflow** (`table/format.cc`): `handle.size()` is a `uint64_t` read from the SST file. On 32-bit platforms the `static_cast<size_t>` silently truncates, and on all platforms `n + kBlockTrailerSize` can wrap to a small value, causing an undersized heap allocation followed by an out-of-bounds write. Added an overflow check before the allocation.

- **ZSTD_getFrameContentSize sentinel mishandling** (`port/port_stdcxx.h`): `ZSTD_getFrameContentSize` returns `ZSTD_CONTENTSIZE_UNKNOWN` (`SIZE_MAX`) or `ZSTD_CONTENTSIZE_ERROR` (`SIZE_MAX-1`) on failure, but only the value `0` was rejected. Passing `SIZE_MAX` as the output buffer size to `ZSTD_decompressDCtx` leads to a massive allocation or undefined behavior. Now both sentinels are properly checked.

- **DecodeEntry uint32 overflow** (`table/block.cc`): The bounds check `(limit - p) < (non_shared + value_length)` performs the addition in `uint32_t`, which can wrap to a small value and bypass the check, leading to out-of-bounds reads. Split into two sequential checks that cannot overflow.

## Test plan

- [ ] Verify existing unit tests still pass (`make check` / `cmake --build . --target leveldb_tests`)
- [ ] Confirm the ReadBlock overflow check rejects a `BlockHandle` with `size()` near `SIZE_MAX`
- [ ] Confirm `Zstd_GetUncompressedLength` returns false for frames that yield `ZSTD_CONTENTSIZE_UNKNOWN` or `ZSTD_CONTENTSIZE_ERROR`
- [ ] Confirm `DecodeEntry` returns nullptr when `non_shared + value_length` would overflow uint32