### PR TITLE
fix: prevent uint32 integer overflow in DecodeEntry bounds check

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -68,7 +68,8 @@ static inline const char* DecodeEntry(const char* p, const char* limit,
     if ((p = GetVarint32Ptr(p, limit, value_length)) == nullptr) return nullptr;
   }
 
-  if (static_cast<uint32_t>(limit - p) < (*non_shared + *value_length)) {
+  uint32_t available = static_cast<uint32_t>(limit - p);
+  if (*non_shared > available || *value_length > available - *non_shared) {
     return nullptr;
   }
   return p;


### PR DESCRIPTION
## Summary

`DecodeEntry()` in `table/block.cc` checks:

```cpp
if (static_cast<uint32_t>(limit - p) < (*non_shared + *value_length))
```

When `non_shared + value_length` wraps mod 2³² (e.g. `0x80000060 + 0x80000000 = 0x60`), the bounds check passes even though the actual read would span ~2.1 GB. `ParseNextKey()` then calls `key_.append(p, non_shared)` which performs an out-of-bounds heap read.

Confirmed with AddressSanitizer: `READ of size 2147483744` from `Block::Iter::ParseNextKey()` via `leveldb::RepairDB()` on a crafted `.ldb` file.

## Fix

Replace the single addition (which can wrap) with two individual unsigned comparisons:

```cpp
uint32_t available = static_cast<uint32_t>(limit - p);
if (*non_shared > available || *value_length > available - *non_shared) {
    return nullptr;
}
```

This mirrors the safe pattern used for similar checks in other parts of the codebase.

## Impact

Any code path that opens or iterates a LevelDB table containing a crafted SSTable — including `RepairDB()`, `DB::Open()`, and direct `Table::Open()` — is affected. A single 512-byte `.ldb` file triggers the overflow without requiring a valid MANIFEST or other database files.