### PR TITLE
fix: record new appendable memenv files

### DIFF
--- a/helpers/memenv/memenv.cc
+++ b/helpers/memenv/memenv.cc
@@ -281,6 +281,7 @@ class InMemoryEnv : public EnvWrapper {
     if (file == nullptr) {
       file = new FileState();
       file->Ref();
+      *sptr = file;
     }
     *result = new WritableFileImpl(file);
     return Status::OK();

--- a/helpers/memenv/memenv_test.cc
+++ b/helpers/memenv/memenv_test.cc
@@ -91,6 +91,29 @@ TEST_F(MemEnvTest, Basics) {
   ASSERT_LEVELDB_OK(env_->RemoveDir("/dir"));
 }
 
+TEST_F(MemEnvTest, NewAppendableFileCreatesFile) {
+  uint64_t file_size;
+  WritableFile* writable_file;
+
+  ASSERT_LEVELDB_OK(env_->CreateDir("/dir"));
+
+  ASSERT_LEVELDB_OK(env_->NewAppendableFile("/dir/f", &writable_file));
+  ASSERT_LEVELDB_OK(writable_file->Append("abc"));
+  delete writable_file;
+
+  ASSERT_TRUE(env_->FileExists("/dir/f"));
+  ASSERT_LEVELDB_OK(env_->GetFileSize("/dir/f", &file_size));
+  ASSERT_EQ(3, file_size);
+
+  SequentialFile* seq_file;
+  Slice result;
+  char scratch[10];
+  ASSERT_LEVELDB_OK(env_->NewSequentialFile("/dir/f", &seq_file));
+  ASSERT_LEVELDB_OK(seq_file->Read(10, &result, scratch));
+  ASSERT_EQ(0, result.compare("abc"));
+  delete seq_file;
+}
+
 TEST_F(MemEnvTest, ReadWrite) {
   WritableFile* writable_file;
   SequentialFile* seq_file;


### PR DESCRIPTION
## Summary

Fixes #1328.

`InMemoryEnv::NewAppendableFile()` currently creates a new `FileState` for missing files but does not store that pointer back into `file_map_`. The map entry remains null, so later operations that look up the filename can dereference a null `FileState`.

This stores the newly-created `FileState` in the map and adds a regression test that creates a file with `NewAppendableFile()`, appends data, then verifies size and sequential reads through the environment.

## Validation

- `git diff --check`
