### PR TITLE
docs: correct MemTable entry format comments

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -77,7 +77,7 @@ void MemTable::Add(SequenceNumber s, ValueType type, const Slice& key,
                    const Slice& value) {
   // Format of an entry is concatenation of:
   //  key_size     : varint32 of internal_key.size()
-  //  key bytes    : char[internal_key.size()]
+  //  key bytes    : char[key.size()]
   //  tag          : uint64((sequence << 8) | type)
   //  value_size   : varint32 of value.size()
   //  value bytes  : char[value.size()]
@@ -106,7 +106,7 @@ bool MemTable::Get(const LookupKey& key, std::string* value, Status* s) {
   if (iter.Valid()) {
     // entry format is:
     //    klength  varint32
-    //    userkey  char[klength]
+    //    userkey  char[klength - 8]
     //    tag      uint64
     //    vlength  varint32
     //    value    char[vlength]


### PR DESCRIPTION
Corrects two MemTable entry format comments so they match the actual internal key layout.

`klength` stores the internal key length, which includes the 8-byte tag. In `Add`, the copied key bytes are `key.size()` and the tag is written separately.

Tests:
- `git diff --check`
- `cmake -S . -B /tmp/leveldb-comment-build-lib -DLEVELDB_BUILD_TESTS=OFF -DLEVELDB_BUILD_BENCHMARKS=OFF`

Fixes #1281.
