### PR TITLE
Fix Zstd config guard macro

### DIFF
--- a/port/port_config.h.in
+++ b/port/port_config.h.in
@@ -31,7 +31,7 @@
 #endif  // !defined(HAVE_SNAPPY)
 
 // Define to 1 if you have Zstd.
-#if !defined(HAVE_Zstd)
+#if !defined(HAVE_ZSTD)
 #cmakedefine01 HAVE_ZSTD
 #endif  // !defined(HAVE_ZSTD)
 


### PR DESCRIPTION
Fixes #1331.

## Summary
- Correct the `HAVE_ZSTD` guard in `port/port_config.h.in` so generated config headers respect an existing `HAVE_ZSTD` definition.
- Align the guard spelling with `CMakeLists.txt` and `port/port_stdcxx.h`.

## Verification
- `cmake -S . -B build-verify -DLEVELDB_BUILD_TESTS=OFF -DLEVELDB_BUILD_BENCHMARKS=OFF -DLEVELDB_INSTALL=OFF -DHAVE_ZSTD=1`
- `cmake -S . -B build -DLEVELDB_BUILD_BENCHMARKS=OFF -DLEVELDB_INSTALL=OFF`
- `cmake --build build --parallel 4`
- `ctest --test-dir build --output-on-failure`
