### PR TITLE
Fix short SequentialFile reads that could drop WAL/MANIFEST data

### DIFF
--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -192,14 +192,27 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result) {
       if (!eof_) {
         // Last read was a full read, so this is a trailer to skip
         buffer_.clear();
-        Status status = file_->Read(kBlockSize, &buffer_, backing_store_);
-        end_of_buffer_offset_ += buffer_.size();
-        if (!status.ok()) {
-          buffer_.clear();
-          ReportDrop(kBlockSize, status);
-          eof_ = true;
-          return kEof;
-        } else if (buffer_.size() < kBlockSize) {
+        size_t nread = 0;
+        Status status;
+        while (nread < kBlockSize) {
+          Slice chunk;
+          status = file_->Read(kBlockSize - nread, &chunk,
+                                backing_store_ + nread);
+          if (!status.ok()) {
+            buffer_.clear();
+            ReportDrop(kBlockSize, status);
+            eof_ = true;
+            return kEof;
+          }
+          if (chunk.size() == 0) {
+            eof_ = true;
+            break;
+          }
+          nread += chunk.size();
+        }
+        end_of_buffer_offset_ += nread;
+        buffer_ = Slice(backing_store_, nread);
+        if (nread < kBlockSize) {
           eof_ = true;
         }
         continue;

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include <algorithm>
+#include <cstring>
+
 #include "gtest/gtest.h"
 #include "db/log_reader.h"
 #include "db/log_writer.h"
@@ -174,22 +177,24 @@ class LogTest : public testing::Test {
 
   class StringSource : public SequentialFile {
    public:
-    StringSource() : force_error_(false), returned_partial_(false) {}
+    StringSource() : force_error_(false) {}
 
     Status Read(size_t n, Slice* result, char* scratch) override {
-      EXPECT_TRUE(!returned_partial_) << "must not Read() after eof/error";
-
       if (force_error_) {
         force_error_ = false;
-        returned_partial_ = true;
         return Status::Corruption("read error");
+      }
+
+      if (contents_.empty()) {
+        *result = Slice(scratch, 0);
+        return Status::OK();
       }
 
       if (contents_.size() < n) {
         n = contents_.size();
-        returned_partial_ = true;
       }
-      *result = Slice(contents_.data(), n);
+      std::memcpy(scratch, contents_.data(), n);
+      *result = Slice(scratch, n);
       contents_.remove_prefix(n);
       return Status::OK();
     }
@@ -207,7 +212,6 @@ class LogTest : public testing::Test {
 
     Slice contents_;
     bool force_error_;
-    bool returned_partial_;
   };
 
   class ReportCollector : public Reader::Reporter {
@@ -257,6 +261,73 @@ uint64_t LogTest::initial_offset_last_record_offsets_[] = {
 // LogTest::initial_offset_last_record_offsets_ must be defined before this.
 int LogTest::num_initial_offset_records_ =
     sizeof(LogTest::initial_offset_last_record_offsets_) / sizeof(uint64_t);
+
+// Returns at most |max_per_read| bytes per call, even when more data is
+// available. Simulates a SequentialFile::Read() that returns short reads
+// before end-of-file (e.g. due to EINTR after a partial read).
+class PartialReadSource : public SequentialFile {
+ public:
+  PartialReadSource(std::string contents, size_t max_per_read)
+      : contents_(std::move(contents)), max_per_read_(max_per_read) {}
+
+  Status Read(size_t n, Slice* result, char* scratch) override {
+    if (contents_.empty()) {
+      *result = Slice(scratch, 0);
+      return Status::OK();
+    }
+    const size_t to_read =
+        std::min(n, std::min(max_per_read_, contents_.size()));
+    std::memcpy(scratch, contents_.data(), to_read);
+    *result = Slice(scratch, to_read);
+    contents_.erase(0, to_read);
+    return Status::OK();
+  }
+
+  Status Skip(uint64_t n) override {
+    if (n > contents_.size()) {
+      contents_.clear();
+      return Status::NotFound("in-memory file skipped past end");
+    }
+    contents_.erase(0, static_cast<size_t>(n));
+    return Status::OK();
+  }
+
+ private:
+  std::string contents_;
+  const size_t max_per_read_;
+};
+
+TEST(PartialReadSourceTest, LogReaderRetriesShortReads) {
+  class StringDest : public WritableFile {
+   public:
+    Status Close() override { return Status::OK(); }
+    Status Flush() override { return Status::OK(); }
+    Status Sync() override { return Status::OK(); }
+    Status Append(const Slice& slice) override {
+      contents_.append(slice.data(), slice.size());
+      return Status::OK();
+    }
+
+    std::string contents_;
+  };
+
+  StringDest dest;
+  Writer writer(&dest);
+  ASSERT_TRUE(writer.AddRecord(Slice("first")).ok());
+  ASSERT_TRUE(writer.AddRecord(Slice(BigString("x", 2 * kBlockSize))).ok());
+
+  PartialReadSource source(dest.contents_, 1000);
+  Reader::Reporter* reporter = nullptr;
+  Reader reader(&source, reporter, true /*checksum*/, 0 /*initial_offset*/);
+
+  Slice record;
+  std::string scratch;
+  ASSERT_TRUE(reader.ReadRecord(&record, &scratch));
+  ASSERT_EQ("first", record.ToString());
+  ASSERT_TRUE(reader.ReadRecord(&record, &scratch));
+  ASSERT_EQ(2 * kBlockSize, record.size());
+  ASSERT_FALSE(reader.ReadRecord(&record, &scratch));
+}
 
 TEST_F(LogTest, Empty) { ASSERT_EQ("EOF", Read()); }
 

--- a/include/leveldb/env.h
+++ b/include/leveldb/env.h
@@ -231,6 +231,9 @@ class LEVELDB_EXPORT SequentialFile {
   // Read up to "n" bytes from the file.  "scratch[0..n-1]" may be
   // written by this routine.  Sets "*result" to the data that was
   // read (including if fewer than "n" bytes were successfully read).
+  // Implementations should only return fewer than "n" bytes when end
+  // of file is reached; if interrupted while reading, they should
+  // retry and return as many bytes as requested (or until EOF).
   // May set "*result" to point at data in "scratch[0..n-1]", so
   // "scratch[0..n-1]" must be live when "*result" is used.
   // If an error was encountered, returns a non-OK status.

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -140,20 +140,22 @@ class PosixSequentialFile final : public SequentialFile {
   ~PosixSequentialFile() override { close(fd_); }
 
   Status Read(size_t n, Slice* result, char* scratch) override {
-    Status status;
-    while (true) {
-      ::ssize_t read_size = ::read(fd_, scratch, n);
+    size_t nread = 0;
+    while (nread < n) {
+      ::ssize_t read_size = ::read(fd_, scratch + nread, n - nread);
       if (read_size < 0) {  // Read error.
         if (errno == EINTR) {
           continue;  // Retry
         }
-        status = PosixError(filename_, errno);
-        break;
+        return PosixError(filename_, errno);
       }
-      *result = Slice(scratch, read_size);
-      break;
+      if (read_size == 0) {
+        break;  // EOF
+      }
+      nread += static_cast<size_t>(read_size);
     }
-    return status;
+    *result = Slice(scratch, nread);
+    return Status::OK();
   }
 
   Status Skip(uint64_t n) override {

--- a/util/env_windows.cc
+++ b/util/env_windows.cc
@@ -170,17 +170,25 @@ class WindowsSequentialFile : public SequentialFile {
   ~WindowsSequentialFile() override {}
 
   Status Read(size_t n, Slice* result, char* scratch) override {
-    DWORD bytes_read;
-    // DWORD is 32-bit, but size_t could technically be larger. However leveldb
-    // files are limited to leveldb::Options::max_file_size which is clamped to
-    // 1<<30 or 1 GiB.
-    assert(n <= std::numeric_limits<DWORD>::max());
-    if (!::ReadFile(handle_.get(), scratch, static_cast<DWORD>(n), &bytes_read,
-                    nullptr)) {
-      return WindowsError(filename_, ::GetLastError());
+    size_t nread = 0;
+    while (nread < n) {
+      DWORD bytes_read = 0;
+      const size_t bytes_left = n - nread;
+      // DWORD is 32-bit, but size_t could technically be larger. However
+      // leveldb files are limited to leveldb::Options::max_file_size which is
+      // clamped to 1<<30 or 1 GiB.
+      assert(bytes_left <= std::numeric_limits<DWORD>::max());
+      if (!::ReadFile(handle_.get(), scratch + nread,
+                      static_cast<DWORD>(bytes_left), &bytes_read, nullptr)) {
+        return WindowsError(filename_, ::GetLastError());
+      }
+      if (bytes_read == 0) {
+        break;  // EOF
+      }
+      nread += bytes_read;
     }
 
-    *result = Slice(scratch, bytes_read);
+    *result = Slice(scratch, nread);
     return Status::OK();
   }
 


### PR DESCRIPTION
## Summary

Fixes a data-loss risk when `SequentialFile::Read()` returns a successful short read before EOF (e.g. POSIX `read()` interrupted by a signal after partially filling the buffer). `log::Reader` previously treated any short read as EOF, which could silently drop MANIFEST or WAL data during `DB::Open()`.

## Changes

- **`util/env_posix.cc`**: `PosixSequentialFile::Read` loops until `n` bytes are read or EOF.
- **`util/env_windows.cc`**: Same retry loop for `WindowsSequentialFile::Read`.
- **`db/log_reader.cc`**: `ReadPhysicalRecord` accumulates partial block reads before treating EOF.
- **`include/leveldb/env.h`**: Document that implementations should only return short reads at EOF.
- **`db/log_test.cc`**: Add `PartialReadSourceTest` regression test; update `StringSource` mock to match real EOF semantics.

## Testing

Built and ran on Linux (CMake Release):

```
./leveldb_tests --gtest_filter="*PartialRead*"          # 1/1 passed
./leveldb_tests --gtest_filter="LogTest.*:PartialReadSourceTest.*"  # 39/39 passed
./env_posix_test                                       # 7/7 passed
./leveldb_tests                                        # 210 passed, 2 skipped
```

Did not run Windows or macOS CI matrix locally.

Related: #1285