### PR TITLE
Do not reuse logs that end with an incomplete record

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -469,7 +469,8 @@ Status DBImpl::RecoverLogFile(uint64_t log_number, bool last_log,
   delete file;
 
   // See if we should keep reusing the last log file.
-  if (status.ok() && options_.reuse_logs && last_log && compactions == 0) {
+  if (status.ok() && options_.reuse_logs && last_log && compactions == 0 &&
+      !reader.HasIncompleteTrailingRecord()) {
     assert(logfile_ == nullptr);
     assert(log_ == nullptr);
     assert(mem_ == nullptr);

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -23,6 +23,7 @@ Reader::Reader(SequentialFile* file, Reporter* reporter, bool checksum,
       backing_store_(new char[kBlockSize]),
       buffer_(),
       eof_(false),
+      incomplete_trailing_record_(false),
       last_record_offset_(0),
       end_of_buffer_offset_(0),
       initial_offset_(initial_offset),
@@ -146,6 +147,7 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch) {
           // This can be caused by the writer dying immediately after
           // writing a physical record but before completing the next; don't
           // treat it as a corruption, just ignore the entire logical record.
+          incomplete_trailing_record_ = true;
           scratch->clear();
         }
         return false;
@@ -208,6 +210,9 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result) {
         // end of the file, which can be caused by the writer crashing in the
         // middle of writing the header. Instead of considering this an error,
         // just report EOF.
+        if (!buffer_.empty()) {
+          incomplete_trailing_record_ = true;
+        }
         buffer_.clear();
         return kEof;
       }
@@ -229,6 +234,7 @@ unsigned int Reader::ReadPhysicalRecord(Slice* result) {
       // If the end of the file has been reached without reading |length| bytes
       // of payload, assume the writer died in the middle of writing the record.
       // Don't report a corruption.
+      incomplete_trailing_record_ = true;
       return kEof;
     }
 

--- a/db/log_reader.h
+++ b/db/log_reader.h
@@ -60,6 +60,13 @@ class Reader {
   // Undefined before the first call to ReadRecord.
   uint64_t LastRecordOffset();
 
+  // Returns true if reading stopped because the file ended with an incomplete
+  // log record (e.g. the writer crashed mid-record). Logs with incomplete
+  // trailing records must not be reused for append.
+  bool HasIncompleteTrailingRecord() const {
+    return incomplete_trailing_record_;
+  }
+
  private:
   // Extend record types with the following special values
   enum {
@@ -91,6 +98,7 @@ class Reader {
   char* const backing_store_;
   Slice buffer_;
   bool eof_;  // Last Read() indicated EOF by returning < kBlockSize
+  bool incomplete_trailing_record_;
 
   // Offset of the last record returned by ReadRecord.
   uint64_t last_record_offset_;

--- a/db/log_test.cc
+++ b/db/log_test.cc
@@ -122,6 +122,15 @@ class LogTest : public testing::Test {
     reader_ = new Reader(&source_, &report_, true /*checksum*/, initial_offset);
   }
 
+  void DrainRecords() {
+    while (Read() != "EOF") {
+    }
+  }
+
+  bool HasIncompleteTrailingRecord() const {
+    return reader_->HasIncompleteTrailingRecord();
+  }
+
   void CheckOffsetPastEndReturnsNoRecords(uint64_t offset_past_end) {
     WriteInitialOffsetLog();
     reading_ = true;
@@ -473,6 +482,20 @@ TEST_F(LogTest, PartialLastIsIgnored) {
   ASSERT_EQ("EOF", Read());
   ASSERT_EQ("", ReportMessage());
   ASSERT_EQ(0, DroppedBytes());
+}
+
+TEST_F(LogTest, IncompleteTrailingRecordDetected) {
+  Write("foo");
+  ShrinkSize(1);
+  DrainRecords();
+  ASSERT_TRUE(HasIncompleteTrailingRecord());
+}
+
+TEST_F(LogTest, CompleteTrailingRecordNotIncomplete) {
+  Write("foo");
+  ASSERT_EQ("foo", Read());
+  ASSERT_EQ("EOF", Read());
+  ASSERT_FALSE(HasIncompleteTrailingRecord());
 }
 
 TEST_F(LogTest, SkipIntoMultiRecord) {

--- a/db/recovery_test.cc
+++ b/db/recovery_test.cc
@@ -216,6 +216,34 @@ TEST_F(RecoveryTest, NoLogFiles) {
   ASSERT_EQ("NOT_FOUND", Get("foo"));
 }
 
+TEST_F(RecoveryTest, LogNotReusedWithIncompleteTrailingRecord) {
+  if (!CanAppend()) {
+    std::fprintf(stderr,
+                 "skipping test because env does not support appending\n");
+    return;
+  }
+  ASSERT_LEVELDB_OK(Put("foo", "bar"));
+  ASSERT_LEVELDB_OK(Put("baz", "qux"));
+  Close();
+  uint64_t old_log = FirstLogFile();
+  ASSERT_LT(0u, FileSize(LogName(old_log)));
+
+  std::string contents;
+  ASSERT_LEVELDB_OK(ReadFileToString(env(), LogName(old_log), &contents));
+  contents.resize(contents.size() - 1);
+  {
+    WritableFile* file = nullptr;
+    ASSERT_LEVELDB_OK(env()->NewWritableFile(LogName(old_log), &file));
+    ASSERT_LEVELDB_OK(file->Append(contents));
+    ASSERT_LEVELDB_OK(file->Close());
+    delete file;
+  }
+
+  ASSERT_LEVELDB_OK(OpenWithStatus());
+  ASSERT_EQ("bar", Get("foo"));
+  ASSERT_NE(old_log, FirstLogFile()) << "must not reuse log with incomplete tail";
+}
+
 TEST_F(RecoveryTest, LogFileReuse) {
   if (!CanAppend()) {
     std::fprintf(stderr,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -898,6 +898,7 @@ Status VersionSet::Recover(bool* save_manifest) {
   uint64_t prev_log_number = 0;
   Builder builder(this, current_);
   int read_records = 0;
+  bool manifest_has_incomplete_trailing_record = false;
 
   {
     LogReporter reporter;
@@ -943,6 +944,8 @@ Status VersionSet::Recover(bool* save_manifest) {
         have_last_sequence = true;
       }
     }
+    manifest_has_incomplete_trailing_record =
+        reader.HasIncompleteTrailingRecord();
   }
   delete file;
   file = nullptr;
@@ -977,7 +980,8 @@ Status VersionSet::Recover(bool* save_manifest) {
     prev_log_number_ = prev_log_number;
 
     // See if we can reuse the existing MANIFEST file.
-    if (ReuseManifest(dscname, current)) {
+    if (!manifest_has_incomplete_trailing_record &&
+        ReuseManifest(dscname, current)) {
       // No need to save new manifest
     } else {
       *save_manifest = true;


### PR DESCRIPTION
## Summary

Fixes a corruption risk when `reuse_logs` is enabled and a WAL or MANIFEST ends with an incomplete record (writer crashed mid-record). Previously `log::Reader` silently discarded the partial tail, then reuse appended new data — turning a safe discard into likely corruption.

## Changes

- **`db/log_reader.h` / `db/log_reader.cc`**: Add `HasIncompleteTrailingRecord()`; set when EOF discards truncated header, partial payload, or incomplete fragmented record.
- **`db/db_impl.cc`**: Skip WAL reuse in `RecoverLogFile` when the flag is set.
- **`db/version_set.cc`**: Skip MANIFEST reuse in `Recover` when the flag is set.
- **`db/log_test.cc`**: Unit tests for complete vs incomplete EOF.
- **`db/recovery_test.cc`**: Integration test that truncated WAL is not reused (`reuse_logs`).

## Testing

Linux (CMake Release):

```
./leveldb_tests --gtest_filter="LogTest.Incomplete*:LogTest.Complete*:RecoveryTest.LogNot*:RecoveryTest.LogFileReuse:RecoveryTest.ManifestReused"  # 5/5 passed
./leveldb_tests  # 212 passed, 2 skipped
./env_posix_test  # not re-run (unchanged POSIX env paths)
```

Did not run Windows/macOS builds locally; relies on CI.

Related: #1287