### PR TITLE
Reject oversized block handles before ReadBlock allocation

### DIFF
--- a/table/format.cc
+++ b/table/format.cc
@@ -4,6 +4,8 @@
 
 #include "table/format.h"
 
+#include <limits>
+
 #include "leveldb/env.h"
 #include "leveldb/options.h"
 #include "port/port.h"
@@ -74,15 +76,20 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
 
   // Read the block contents as well as the type/crc footer.
   // See table_builder.cc for the code that built this structure.
-  size_t n = static_cast<size_t>(handle.size());
-  char* buf = new char[n + kBlockTrailerSize];
+  const uint64_t raw_size = handle.size();
+  if (raw_size > std::numeric_limits<size_t>::max() - kBlockTrailerSize) {
+    return Status::Corruption("block is too large");
+  }
+  const size_t n = static_cast<size_t>(raw_size);
+  const size_t read_len = n + kBlockTrailerSize;
+  char* buf = new char[read_len];
   Slice contents;
-  Status s = file->Read(handle.offset(), n + kBlockTrailerSize, &contents, buf);
+  Status s = file->Read(handle.offset(), read_len, &contents, buf);
   if (!s.ok()) {
     delete[] buf;
     return s;
   }
-  if (contents.size() != n + kBlockTrailerSize) {
+  if (contents.size() != read_len) {
     delete[] buf;
     return Status::Corruption("truncated block read");
   }

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -4,6 +4,7 @@
 
 #include "leveldb/table.h"
 
+#include <limits>
 #include <map>
 #include <string>
 
@@ -837,6 +838,48 @@ TEST_P(CompressionTableTest, ApproximateOffsetOfCompressed) {
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k04"), min_z, max_z));
   // Have now emitted two large compressible strings, so adjust expected offset.
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"), 2 * min_z, 2 * max_z));
+}
+
+TEST(ReadBlockTest, RejectsOversizedBlockHandle) {
+  char backing[64];
+  std::memset(backing, 0, sizeof(backing));
+  StringSource source(Slice(backing, sizeof(backing)));
+  ReadOptions read_options;
+  read_options.verify_checksums = false;
+  BlockContents result;
+
+  const uint64_t bad_sizes[] = {
+      std::numeric_limits<uint64_t>::max() - 4,
+      std::numeric_limits<uint64_t>::max(),
+      static_cast<uint64_t>(std::numeric_limits<size_t>::max()),
+  };
+
+  for (uint64_t size : bad_sizes) {
+    BlockHandle handle;
+    handle.set_offset(0);
+    handle.set_size(size);
+
+    Status s = ReadBlock(&source, read_options, handle, &result);
+    ASSERT_TRUE(!s.ok()) << "size=" << size;
+    ASSERT_TRUE(s.IsCorruption()) << s.ToString();
+  }
+}
+
+TEST(ReadBlockTest, TruncatedBlockRead) {
+  char backing[16];
+  std::memset(backing, 0, sizeof(backing));
+  StringSource source(Slice(backing, sizeof(backing)));
+  ReadOptions read_options;
+  read_options.verify_checksums = false;
+  BlockContents result;
+
+  BlockHandle handle;
+  handle.set_offset(0);
+  handle.set_size(100);
+
+  Status s = ReadBlock(&source, read_options, handle, &result);
+  ASSERT_TRUE(!s.ok());
+  ASSERT_TRUE(s.IsCorruption()) << s.ToString();
 }
 
 }  // namespace leveldb


### PR DESCRIPTION
## Problem

`ReadBlock()` narrows attacker-controlled `BlockHandle::size()` to `size_t` and computes `n + kBlockTrailerSize` without checking for overflow. When `size` is near `SIZE_MAX` (e.g. `UINT64_MAX - 4`), the addition wraps to a small value. Allocation, the file read, and the truncated-block check all use that wrapped length consistently, so the safety check is bypassed and `data[n]` reads out of bounds.

This affects any code path that opens attacker-supplied SSTables (`Table::Open`, `leveldbutil dump`, etc.).

Related: #1310

## Fix

Validate `handle.size()` as `uint64_t` before narrowing or adding `kBlockTrailerSize`. Return `Corruption("block is too large")` when the size cannot be represented safely.

## Tests

- `ReadBlockTest.RejectsOversizedBlockHandle` — covers the PoC value (`UINT64_MAX - 4`), `UINT64_MAX`, and `SIZE_MAX`
- `ReadBlockTest.TruncatedBlockRead` — block larger than backing file still returns corruption

## Validation (Linux)

```
mkdir -p build && cd build
cmake -DCMAKE_BUILD_TYPE=Release .. && cmake --build .
./leveldb_tests --gtest_filter='ReadBlockTest.*'   # 2/2 passed
./leveldb_tests                                     # 211 passed, 2 skipped
./env_posix_test                                    # not re-run this round
```

`clang-format` was not run (not installed locally).