### PR TITLE
ci: add permissions and pin actions/checkout to full commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         matrix.optimized && 'RelWithDebInfo' || 'Debug') }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         submodules: true
 


### PR DESCRIPTION
`build.yml` was missing a top-level `permissions:` block and used a mutable `actions/checkout@v2` tag.

- Add `permissions: contents: read`
- Pin `actions/checkout`: `@v2` → `@ee0669bd1cc54295c223e0bb666b733df41de1c5`

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards).