### PR TITLE
fix TableBuilder::ChangeOptions assertion failure when lowering block_restart_interval

### DIFF
--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -85,6 +85,9 @@ Status TableBuilder::ChangeOptions(const Options& options) {
 
   // Note that any live BlockBuilders point to rep_->options and therefore
   // will automatically pick up the updated options.
+  if (!rep_->data_block.empty()) {
+    Flush();
+  }
   rep_->options = options;
   rep_->index_block_options = options;
   rep_->index_block_options.block_restart_interval = 1;


### PR DESCRIPTION
This PR attempts to fix the issue #1339 .

## Problem

`TableBuilder::ChangeOptions` updates `block_restart_interval` in the shared `Options` struct that `BlockBuilder` reads via pointer, but (before this fix) did not reset the data block's internal `counter_`. When the new interval is smaller than the current `counter_`, the next `BlockBuilder::Add` trips:

```
assert(counter_ <= options_->block_restart_interval)
```

at `table/block_builder.cc:74` and aborts.

## Fix

Flush the current data block before applying the new options, so `counter_` is reset via `BlockBuilder::Reset()` (called inside `WriteBlock`):

```cpp
// table/table_builder.cc — inside ChangeOptions, before rep_->options = options

// Before
rep_->options = options;
rep_->index_block_options = options;
rep_->index_block_options.block_restart_interval = 1;

// After
if (!rep_->data_block.empty()) {
  Flush();
}
rep_->options = options;
rep_->index_block_options = options;
rep_->index_block_options.block_restart_interval = 1;
```

This ensures the current block is written with consistent restart points before the new interval takes effect. An alternative would be to weaken the assertion in `block_builder.cc:74` to `assert(counter_ >= 0)`, since the `else` branch already self-corrects — but flushing is preferable because it avoids writing a block with an irregular restart-point pattern.

## Verification

### Sanitizer rebuild

Rebuilt the library with AddressSanitizer and UndefinedBehaviorSanitizer to confirm the assertion crash is gone and no memory/UB issues remain:
```
cmake -S . -B build-san -DLEVELDB_BUILD_TESTS=ON
-DLEVELDB_BUILD_BENCHMARKS=OFF \
-DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -g -O1 -fno-omit-frame-pointer" \
-DCMAKE_C_FLAGS="-fsanitize=address,undefined -g -O1 -fno-omit-frame-pointer"
cmake --build build-san -j
```

### Before fix:
```
Assertion failed: (counter_ <= options_->block_restart_interval), function Add, file block_builder.cc, line 74.
ERROR: AddressSanitizer: ABRT
```

### After fix:

(clean exit, code 0 — no sanitizer errors)

### Test-suite results

Ran the full LevelDB test suite under ASan + UBSan with halt_on_error=1:
```
ASAN_OPTIONS=halt_on_error=1 UBSAN_OPTIONS=halt_on_error=1 \
ctest --test-dir build-san --output-on-failure

100% tests passed out of 3

1/3 Test #1: leveldb_tests ....................   Passed
2/3 Test #2: c_test ...........................   Passed
3/3 Test #3: env_posix_test ...................   Passed
```