### PR TITLE
Simplify internal key trailer comparison

### DIFF
--- a/db/dbformat.cc
+++ b/db/dbformat.cc
@@ -53,11 +53,7 @@ int InternalKeyComparator::Compare(const Slice& akey, const Slice& bkey) const {
   if (r == 0) {
     const uint64_t anum = DecodeFixed64(akey.data() + akey.size() - 8);
     const uint64_t bnum = DecodeFixed64(bkey.data() + bkey.size() - 8);
-    if (anum > bnum) {
-      r = -1;
-    } else if (anum < bnum) {
-      r = +1;
-    }
+    r = (anum < bnum) - (anum > bnum);
   }
   return r;
 }


### PR DESCRIPTION
## Summary

This simplifies the internal key trailer comparison by computing the descending sequence-number ordering with a single integer expression.

## Why this can improve performance

When user keys compare equal, LevelDB orders newer sequence numbers first. The previous code used two branches to set `-1`, `+1`, or `0`. The new expression preserves those return values while avoiding the explicit branch chain.

## Validation

- `git diff --check`
- Existing local build artifact was used during candidate screening; no full fresh benchmark is claimed in this draft.

## Benchmark

Draft note: this patch is submitted for maintainer feedback as a small branch cleanup. Earlier local microbenchmarking of this exact candidate was slightly negative on this machine, so the PR intentionally does not claim a measured speedup.
