### PR TITLE
Keep BlockBuilder restart counter valid after ChangeOptions

### DIFF
--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -52,6 +52,13 @@ void BlockBuilder::Reset() {
   last_key_.clear();
 }
 
+void BlockBuilder::OnOptionsChanged() {
+  assert(options_->block_restart_interval >= 1);
+  if (counter_ > options_->block_restart_interval) {
+    counter_ = options_->block_restart_interval;
+  }
+}
+
 size_t BlockBuilder::CurrentSizeEstimate() const {
   return (buffer_.size() +                       // Raw data buffer
           restarts_.size() * sizeof(uint32_t) +  // Restart array

--- a/table/block_builder.h
+++ b/table/block_builder.h
@@ -24,6 +24,9 @@ class BlockBuilder {
   // Reset the contents as if the BlockBuilder was just constructed.
   void Reset();
 
+  // Reconcile internal counters after the pointed-to Options value changes.
+  void OnOptionsChanged();
+
   // REQUIRES: Finish() has not been called since the last call to Reset().
   // REQUIRES: key is larger than any previously added key
   void Add(const Slice& key, const Slice& value);

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -86,6 +86,7 @@ Status TableBuilder::ChangeOptions(const Options& options) {
   // Note that any live BlockBuilders point to rep_->options and therefore
   // will automatically pick up the updated options.
   rep_->options = options;
+  rep_->data_block.OnOptionsChanged();
   rep_->index_block_options = options;
   rep_->index_block_options.block_restart_interval = 1;
   return Status::OK();

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -256,6 +256,39 @@ class TableConstructor : public Constructor {
   TableConstructor();
 };
 
+TEST(TableTest, ChangeOptionsLowerRestartInterval) {
+  Options options;
+  options.block_restart_interval = 16;
+
+  StringSink sink;
+  TableBuilder builder(options, &sink);
+  for (int i = 0; i < 8; ++i) {
+    builder.Add("key00" + std::to_string(i), "value00" + std::to_string(i));
+    EXPECT_LEVELDB_OK(builder.status());
+  }
+
+  Options changed_options = options;
+  changed_options.block_restart_interval = 2;
+  EXPECT_LEVELDB_OK(builder.ChangeOptions(changed_options));
+
+  builder.Add("key008", "value008");
+  EXPECT_LEVELDB_OK(builder.status());
+  EXPECT_LEVELDB_OK(builder.Finish());
+
+  StringSource source(sink.contents());
+  Table* table = nullptr;
+  EXPECT_LEVELDB_OK(Table::Open(options, &source, sink.contents().size(), &table));
+
+  Iterator* iter = table->NewIterator(ReadOptions());
+  iter->Seek("key008");
+  ASSERT_TRUE(iter->Valid());
+  EXPECT_EQ(iter->key().ToString(), "key008");
+  EXPECT_EQ(iter->value().ToString(), "value008");
+
+  delete iter;
+  delete table;
+}
+
 // A helper class that converts internal format keys into user keys
 class KeyConvertingIterator : public Iterator {
  public:


### PR DESCRIPTION
## Summary

Fixes #1339 by keeping `BlockBuilder`'s restart counter consistent when `TableBuilder::ChangeOptions` lowers `block_restart_interval` after entries have already been added.

## Details

`BlockBuilder::counter_` tracks how many entries have been emitted since the last restart point. If `ChangeOptions` installs a smaller restart interval while `counter_` is already larger than that interval, the next `Add` can violate the builder's restart interval invariant.

This adds an `OnOptionsChanged` hook that clamps the counter to the current interval after the table builder updates its options. The new regression test builds a table block under interval 16, changes the interval to 2, adds another entry, finishes and reopens the table, and verifies that the entry can be found through an iterator.

## Validation

I built and ran the repository's complete `leveldb_tests` binary. Of 212 tests, 211 passed and one compression-dependent test was skipped by the current build configuration; there were no failures.

I also ran the new regression test and the full `TableTest.*` group separately:

```text
./build-pr-submodules/leveldb_tests \
  --gtest_filter=TableTest.ChangeOptionsLowerRestartInterval
./build-pr-submodules/leveldb_tests --gtest_filter=TableTest.*
```

`git diff --check` also passes.
