### PR TITLE
Reject overflowing block entry lengths

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -68,7 +68,8 @@ static inline const char* DecodeEntry(const char* p, const char* limit,
     if ((p = GetVarint32Ptr(p, limit, value_length)) == nullptr) return nullptr;
   }
 
-  if (static_cast<uint32_t>(limit - p) < (*non_shared + *value_length)) {
+  if (static_cast<uint64_t>(limit - p) <
+      static_cast<uint64_t>(*non_shared) + *value_length) {
     return nullptr;
   }
   return p;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -19,6 +19,7 @@
 #include "table/block.h"
 #include "table/block_builder.h"
 #include "table/format.h"
+#include "util/coding.h"
 #include "util/random.h"
 #include "util/testutil.h"
 
@@ -636,6 +637,27 @@ TEST_F(Harness, ZeroRestartPointsInBlock) {
   ASSERT_TRUE(!iter->Valid());
   iter->Seek("foo");
   ASSERT_TRUE(!iter->Valid());
+  delete iter;
+}
+
+TEST_F(Harness, RejectsOverflowingEntryLengths) {
+  std::string data;
+  PutVarint32(&data, 0);
+  PutVarint32(&data, 0x80000000u);
+  PutVarint32(&data, 0x80000001u);
+  data.push_back('x');
+  PutFixed32(&data, 0);
+  PutFixed32(&data, 1);
+
+  BlockContents contents;
+  contents.data = data;
+  contents.cachable = false;
+  contents.heap_allocated = false;
+  Block block(contents);
+  Iterator* iter = block.NewIterator(BytewiseComparator());
+  iter->SeekToFirst();
+  EXPECT_FALSE(iter->Valid());
+  EXPECT_TRUE(iter->status().IsCorruption()) << iter->status().ToString();
   delete iter;
 }
 


### PR DESCRIPTION
Fixes #1348.

`DecodeEntry` compared the remaining block bytes against `non_shared + value_length` after that sum had already been evaluated in `uint32_t`. Crafted varints such as `0x80000000` and `0x80000001` therefore wrapped the sum and bypassed the bounds check.

This casts `non_shared` to `uint64_t` before the addition and adds a focused block-iterator regression for the overflowing pair. The iterator now rejects the entry with a corruption status instead of attempting the out-of-bounds key read.

Validation:
- focused regression passed under AddressSanitizer
- full CTest suite passed: 3/3 targets (`leveldb_tests`, `c_test`, `env_posix_test`)

Reported by @h-t-m in #1348. Thanks for the clear reproducer and coordination.