### PR TITLE
memenv: register the FileState created by NewAppendableFile

### DIFF
--- a/helpers/memenv/memenv.cc
+++ b/helpers/memenv/memenv.cc
@@ -281,6 +281,7 @@ class InMemoryEnv : public EnvWrapper {
     if (file == nullptr) {
       file = new FileState();
       file->Ref();
+      *sptr = file;
     }
     *result = new WritableFileImpl(file);
     return Status::OK();

--- a/helpers/memenv/memenv_test.cc
+++ b/helpers/memenv/memenv_test.cc
@@ -91,6 +91,42 @@ TEST_F(MemEnvTest, Basics) {
   ASSERT_LEVELDB_OK(env_->RemoveDir("/dir"));
 }
 
+TEST_F(MemEnvTest, AppendableFileRegistersNewFile) {
+  // NewAppendableFile() on a file that does not exist yet has to store the
+  // newly created FileState in the file map, the way NewWritableFile() does.
+  // Otherwise the map holds a null FileState under a name that FileExists()
+  // reports as present, and every later lookup dereferences it.
+  WritableFile* writable_file;
+  ASSERT_LEVELDB_OK(env_->NewAppendableFile("/dir/appendable", &writable_file));
+  ASSERT_LEVELDB_OK(writable_file->Append("hello"));
+  ASSERT_LEVELDB_OK(writable_file->Flush());
+  delete writable_file;
+
+  ASSERT_TRUE(env_->FileExists("/dir/appendable"));
+
+  uint64_t file_size = 0;
+  ASSERT_LEVELDB_OK(env_->GetFileSize("/dir/appendable", &file_size));
+  ASSERT_EQ(5, file_size);
+
+  // Re-opening for append must extend the same file, not start a new one.
+  ASSERT_LEVELDB_OK(env_->NewAppendableFile("/dir/appendable", &writable_file));
+  ASSERT_LEVELDB_OK(writable_file->Append(" world"));
+  ASSERT_LEVELDB_OK(writable_file->Flush());
+  delete writable_file;
+
+  ASSERT_LEVELDB_OK(env_->GetFileSize("/dir/appendable", &file_size));
+  ASSERT_EQ(11, file_size);
+
+  SequentialFile* sequential_file;
+  ASSERT_LEVELDB_OK(
+      env_->NewSequentialFile("/dir/appendable", &sequential_file));
+  char scratch[64];
+  Slice result;
+  ASSERT_LEVELDB_OK(sequential_file->Read(sizeof(scratch), &result, scratch));
+  ASSERT_EQ("hello world", result.ToString());
+  delete sequential_file;
+}
+
 TEST_F(MemEnvTest, ReadWrite) {
   WritableFile* writable_file;
   SequentialFile* seq_file;


### PR DESCRIPTION
Fixes #1328.

`InMemoryEnv::NewAppendableFile()` takes a reference to the map slot and, when the file does not exist yet, creates a `FileState` and `Ref()`s it — but never stores it back:

```cpp
FileState** sptr = &file_map_[fname];   // operator[] inserts, value-initialised to nullptr
FileState* file = *sptr;
if (file == nullptr) {
  file = new FileState();
  file->Ref();
  // *sptr is never assigned
}
```

`operator[]` has already inserted the key, so the name stays mapped to `nullptr` while `FileExists()` reports it as present.

### It crashes sooner than the issue suggests

The report describes later lookups dereferencing the null. No second lookup is needed, because `~InMemoryEnv()` unrefs every value in the map (`memenv.cc:227`):

```cpp
Env* env = NewMemEnv(Env::Default());
WritableFile* file;
env->NewAppendableFile("/dir/f", &file);
delete file;
delete env;      // SEGV
```

Under ASan:

```
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000010
The signal is caused by a READ memory access.
    #0 ___pthread_mutex_lock
    #5 Unref  helpers/memenv/memenv.cc:44
    #6 ~InMemoryEnv  helpers/memenv/memenv.cc:227
```

`0x10` is the offset of the mutex inside `FileState`, read through a null `this`.

The `Ref()` also leaked: `WritableFileImpl` takes and drops its own reference in its constructor/destructor, so nothing owned the one created here.

### Fix

One line — `*sptr = file;` — which makes the appendable path match `NewWritableFile()` a few lines above, which already does `file_map_[fname] = file;` for exactly this case.

### Why this was not already caught

`MemEnvTest.Basics` calls `NewAppendableFile("/dir/f", …)` only *after* `NewWritableFile()` has created that same file, so it always takes the `file != nullptr` branch. The new-file branch had no coverage.

The added test appends to a fresh name, checks the size, reopens for append to confirm it extends rather than replaces, and reads the contents back.

### Testing

| Run | Before | After |
| --- | ------ | ----- |
| `MemEnvTest.AppendableFileRegistersNewFile` | SIGSEGV (139) | pass |
| `MemEnvTest.*` | — | 8/8 |
| `ctest` (Debug) | 3/3 | 3/3 |
| `leveldb_tests` under ASan | SEGV | 210 passed, 2 skipped, 0 failed |

The 2 skips are the compression tests, which need snappy/zstd.
