### PR TITLE
table: allow ChangeOptions to lower block_restart_interval mid-block

### DIFF
--- a/table/block_builder.cc
+++ b/table/block_builder.cc
@@ -71,7 +71,10 @@ Slice BlockBuilder::Finish() {
 void BlockBuilder::Add(const Slice& key, const Slice& value) {
   Slice last_key_piece(last_key_);
   assert(!finished_);
-  assert(counter_ <= options_->block_restart_interval);
+  // counter_ can exceed options_->block_restart_interval: options_ aliases the
+  // Options owned by the caller, and TableBuilder::ChangeOptions() may lower
+  // block_restart_interval while this block is still open. The restart branch
+  // below handles that by emitting a restart point on the next key.
   assert(buffer_.empty()  // No values yet?
          || options_->comparator->Compare(key, last_key_piece) > 0);
   size_t shared = 0;

--- a/table/table_builder.cc
+++ b/table/table_builder.cc
@@ -84,7 +84,10 @@ Status TableBuilder::ChangeOptions(const Options& options) {
   }
 
   // Note that any live BlockBuilders point to rep_->options and therefore
-  // will automatically pick up the updated options.
+  // will automatically pick up the updated options. Lowering
+  // block_restart_interval below the number of keys already buffered in the
+  // open data block is allowed; the next Add() simply starts a new restart
+  // point.
   rep_->options = options;
   rep_->index_block_options = options;
   rep_->index_block_options.block_restart_interval = 1;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -839,4 +839,68 @@ TEST_P(CompressionTableTest, ApproximateOffsetOfCompressed) {
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"), 2 * min_z, 2 * max_z));
 }
 
+TEST(TableTest, ChangeOptionsLowersRestartInterval) {
+  // ChangeOptions() rewrites the Options that the live BlockBuilder reads
+  // through a pointer, so lowering block_restart_interval below the number of
+  // keys already accumulated in the open data block leaves counter_ above the
+  // new interval. BlockBuilder::Add() handles that correctly - it takes the
+  // restart branch - so the table must still build and read back intact.
+  Options options;
+  options.block_restart_interval = 16;
+  StringSink sink;
+  TableBuilder builder(options, &sink);
+
+  // Fill the open data block past the interval we are about to switch to.
+  const int kKeys = 8;
+  for (int i = 0; i < kKeys; i++) {
+    char key[16];
+    std::snprintf(key, sizeof(key), "k%02d", i);
+    builder.Add(key, "v");
+    ASSERT_LEVELDB_OK(builder.status());
+  }
+
+  Options lowered = options;
+  lowered.block_restart_interval = 2;
+  ASSERT_LEVELDB_OK(builder.ChangeOptions(lowered));
+
+  // Used to trip assert(counter_ <= options_->block_restart_interval) in
+  // BlockBuilder::Add().
+  for (int i = kKeys; i < 2 * kKeys; i++) {
+    char key[16];
+    std::snprintf(key, sizeof(key), "k%02d", i);
+    builder.Add(key, "v");
+    ASSERT_LEVELDB_OK(builder.status());
+  }
+  ASSERT_LEVELDB_OK(builder.Finish());
+
+  // The block written across the interval change must still be readable, with
+  // every key present and in order.
+  StringSource source(sink.contents());
+  Table* table = nullptr;
+  Options table_options;
+  ASSERT_LEVELDB_OK(
+      Table::Open(table_options, &source, sink.contents().size(), &table));
+
+  Iterator* iter = table->NewIterator(ReadOptions());
+  int found = 0;
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    char key[16];
+    std::snprintf(key, sizeof(key), "k%02d", found);
+    ASSERT_EQ(key, iter->key().ToString());
+    ASSERT_EQ("v", iter->value().ToString());
+    found++;
+  }
+  ASSERT_LEVELDB_OK(iter->status());
+  ASSERT_EQ(2 * kKeys, found);
+
+  // Seeking must work too, which exercises the restart array of that block.
+  iter->Seek("k09");
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ("k09", iter->key().ToString());
+
+  delete iter;
+  delete table;
+}
+
+
 }  // namespace leveldb


### PR DESCRIPTION
Fixes #1339.

`BlockBuilder` holds a `const Options*` that aliases `TableBuilder::Rep::options`, and `TableBuilder::ChangeOptions()` overwrites that struct while a data block is still open — its own comment notes that live `BlockBuilder`s "will automatically pick up the updated options". Nothing resets the open block's `counter_`, so lowering `block_restart_interval` below the number of already-buffered keys leaves `counter_` above the new interval and the next `Add()` aborts:

```
leveldb_tests: table/block_builder.cc:74:
  void leveldb::BlockBuilder::Add(const leveldb::Slice&, const leveldb::Slice&):
  Assertion `counter_ <= options_->block_restart_interval' failed.
```

### The assertion is the only thing wrong

The branch immediately below it already treats `counter_ >= block_restart_interval` as "emit a restart point now", which is exactly the right response to the interval shrinking. Building the same test with `NDEBUG` confirms it:

| Build | Result |
| ----- | ------ |
| Debug (asserts on) | SIGABRT |
| Release (asserts off) | passes — all 16 keys read back in order, and `Seek()` into the affected block works |

Restart offsets are stored explicitly in the block, so a block whose restart points are irregularly spaced is well-formed and readers handle it.

### Why not flush instead

The issue suggests calling `Flush()` inside `ChangeOptions()` so the block is closed before the new interval applies. That works, but it changes the bytes emitted for *every* caller that changes options mid-table — an extra block boundary — in order to fix something that only misfires in debug builds. Removing the stale assertion is behaviour-preserving. Happy to switch to the flush if you would rather have the stronger invariant.

### Testing

The regression test does not just check that the abort is gone: it opens the finished table, iterates all 16 keys verifying order and values, and seeks into the block that straddles the interval change, so the emitted bytes are covered too.

| Run | Before | After |
| --- | ------ | ----- |
| `TableTest.ChangeOptionsLowersRestartInterval` (Debug) | SIGABRT (134) | pass |
| same test (Release) | pass | pass |
| `ctest` (Debug) | 3/3 | 3/3 |
| `leveldb_tests` under ASan | — | 210 passed, 2 skipped, 0 failed |
