### PR TITLE
Fix integer overflow OOB reads in Block::DecodeEntry and ReadBlock

### DIFF
--- a/table/block.cc
+++ b/table/block.cc
@@ -68,7 +68,8 @@ static inline const char* DecodeEntry(const char* p, const char* limit,
     if ((p = GetVarint32Ptr(p, limit, value_length)) == nullptr) return nullptr;
   }
 
-  if (static_cast<uint32_t>(limit - p) < (*non_shared + *value_length)) {
+  const uint32_t remaining = static_cast<uint32_t>(limit - p);
+  if (*non_shared > remaining || *value_length > remaining - *non_shared) {
     return nullptr;
   }
   return p;

--- a/table/format.cc
+++ b/table/format.cc
@@ -75,6 +75,10 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
   // Read the block contents as well as the type/crc footer.
   // See table_builder.cc for the code that built this structure.
   size_t n = static_cast<size_t>(handle.size());
+  if (n > static_cast<size_t>(64u << 20) ||
+      n + kBlockTrailerSize < n) {
+    return Status::Corruption("block size is too large or overflows");
+  }
   char* buf = new char[n + kBlockTrailerSize];
   Slice contents;
   Status s = file->Read(handle.offset(), n + kBlockTrailerSize, &contents, buf);


### PR DESCRIPTION
## Summary

Two integer overflow bugs in the SST table reader allow crafted SST files to trigger heap-buffer-overflow reads. Both confirmed under AddressSanitizer.

## Bug 1: uint32 overflow in `DecodeEntry` (`table/block.cc:71`)

The bounds check `static_cast<uint32_t>(limit - p) < (*non_shared + *value_length)` wraps when `non_shared + value_length` exceeds 2^32. A crafted entry with `non_shared=50, value_length=0xFFFFFFD0` wraps the sum to 2, bypasses the check, then `key_.append(p, 50)` reads 50 bytes from a buffer with only 5 remaining.

**Fix:** Check each field sequentially against remaining space instead of summing.

## Bug 2: `size_t` overflow in `ReadBlock` (`table/format.cc:78`)

`new char[n + kBlockTrailerSize]` wraps when `handle.size()` is near SIZE_MAX, allocating a tiny buffer. Then `data[n]` at line 102 reads at offset ~SIZE_MAX.

**Fix:** Cap block size at 64MB and check for arithmetic overflow before allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)