### PR TITLE
Harden ReadBlock against oversized decompression allocations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,7 @@ if(LEVELDB_BUILD_TESTS)
         "db/write_batch_test.cc"
         "helpers/memenv/memenv_test.cc"
         "table/filter_block_test.cc"
+        "table/format_1349_test.cc"
         "table/table_test.cc"
         "util/arena_test.cc"
         "util/bloom_test.cc"

--- a/port/port_stdcxx.h
+++ b/port/port_stdcxx.h
@@ -37,6 +37,7 @@
 #include <condition_variable>  // NOLINT
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <mutex>  // NOLINT
 #include <string>
 
@@ -118,6 +119,16 @@ inline bool Snappy_GetUncompressedLength(const char* input, size_t length,
 #endif  // HAVE_SNAPPY
 }
 
+inline bool Snappy_ValidateCompressedBuffer(const char* input, size_t length) {
+#if HAVE_SNAPPY
+  return snappy::IsValidCompressedBuffer(input, length);
+#else
+  (void)input;
+  (void)length;
+  return false;
+#endif  // HAVE_SNAPPY
+}
+
 inline bool Snappy_Uncompress(const char* input, size_t length, char* output) {
 #if HAVE_SNAPPY
   return snappy::RawUncompress(input, length, output);
@@ -163,15 +174,57 @@ inline bool Zstd_Compress(int level, const char* input, size_t length,
 inline bool Zstd_GetUncompressedLength(const char* input, size_t length,
                                        size_t* result) {
 #if HAVE_ZSTD
-  size_t size = ZSTD_getFrameContentSize(input, length);
-  if (size == 0) return false;
-  *result = size;
+  const unsigned long long size = ZSTD_getFrameContentSize(input, length);
+  if (size == 0 || size == ZSTD_CONTENTSIZE_ERROR ||
+      size == ZSTD_CONTENTSIZE_UNKNOWN ||
+      size > std::numeric_limits<size_t>::max()) {
+    return false;
+  }
+  *result = static_cast<size_t>(size);
   return true;
 #else
   // Silence compiler warnings about unused arguments.
   (void)input;
   (void)length;
   (void)result;
+  return false;
+#endif  // HAVE_ZSTD
+}
+
+inline bool Zstd_ValidateCompressedBuffer(const char* input, size_t length) {
+#if HAVE_ZSTD
+  ZSTD_DCtx* ctx = ZSTD_createDCtx();
+  if (ctx == nullptr) return false;
+
+  char scratch[64 * 1024];
+  ZSTD_inBuffer in = {input, length, 0};
+  size_t last_in_pos = static_cast<size_t>(-1);
+
+  while (true) {
+    ZSTD_outBuffer out = {scratch, sizeof(scratch), 0};
+    const size_t rc = ZSTD_decompressStream(ctx, &out, &in);
+    if (ZSTD_isError(rc)) {
+      ZSTD_freeDCtx(ctx);
+      return false;
+    }
+    if (rc == 0) {
+      const bool consumed_all = (in.pos == in.size);
+      ZSTD_freeDCtx(ctx);
+      return consumed_all;
+    }
+    if (in.pos == in.size && out.pos == 0) {
+      ZSTD_freeDCtx(ctx);
+      return false;
+    }
+    if (in.pos == last_in_pos && out.pos == 0) {
+      ZSTD_freeDCtx(ctx);
+      return false;
+    }
+    last_in_pos = in.pos;
+  }
+#else
+  (void)input;
+  (void)length;
   return false;
 #endif  // HAVE_ZSTD
 }

--- a/table/format.cc
+++ b/table/format.cc
@@ -4,6 +4,8 @@
 
 #include "table/format.h"
 
+#include <new>
+
 #include "leveldb/env.h"
 #include "leveldb/options.h"
 #include "port/port.h"
@@ -12,6 +14,10 @@
 #include "util/crc32c.h"
 
 namespace leveldb {
+
+namespace {
+constexpr size_t kDecompressionFastPathBytes = 8 * 1024 * 1024;
+}  // namespace
 
 void BlockHandle::EncodeTo(std::string* dst) const {
   // Sanity check that all fields have been set
@@ -123,7 +129,19 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
         delete[] buf;
         return Status::Corruption("corrupted snappy compressed block length");
       }
-      char* ubuf = new char[ulength];
+      // Ordinary blocks stay on the original one-pass fast path. Large
+      // declarations are validated before any equally large allocation. This
+      // threshold selects an implementation path; it does not reject valid data.
+      if (ulength > kDecompressionFastPathBytes &&
+          !port::Snappy_ValidateCompressedBuffer(data, n)) {
+        delete[] buf;
+        return Status::Corruption("corrupted snappy compressed block contents");
+      }
+      char* ubuf = new (std::nothrow) char[ulength];
+      if (ubuf == nullptr) {
+        delete[] buf;
+        return Status::Corruption("snappy block allocation failed");
+      }
       if (!port::Snappy_Uncompress(data, n, ubuf)) {
         delete[] buf;
         delete[] ubuf;
@@ -141,7 +159,18 @@ Status ReadBlock(RandomAccessFile* file, const ReadOptions& options,
         delete[] buf;
         return Status::Corruption("corrupted zstd compressed block length");
       }
-      char* ubuf = new char[ulength];
+      // Ordinary blocks use the original one-pass decompressor. Large
+      // declarations use bounded streaming validation before the large allocation.
+      if (ulength > kDecompressionFastPathBytes &&
+          !port::Zstd_ValidateCompressedBuffer(data, n)) {
+        delete[] buf;
+        return Status::Corruption("corrupted zstd compressed block contents");
+      }
+      char* ubuf = new (std::nothrow) char[ulength];
+      if (ubuf == nullptr) {
+        delete[] buf;
+        return Status::Corruption("zstd block allocation failed");
+      }
       if (!port::Zstd_Uncompress(data, n, ubuf)) {
         delete[] buf;
         delete[] ubuf;

--- a/table/format_1349_test.cc
+++ b/table/format_1349_test.cc
@@ -1,0 +1,134 @@
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "table/format.h"
+
+#include <cstring>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "leveldb/env.h"
+#include "leveldb/options.h"
+#include "port/port.h"
+
+namespace leveldb {
+namespace {
+
+class StringSource1349 : public RandomAccessFile {
+ public:
+  explicit StringSource1349(std::string data) : data_(std::move(data)) {}
+  Status Read(uint64_t offset, size_t n, Slice* result,
+              char* scratch) const override {
+    if (offset > data_.size()) return Status::IOError("offset");
+    const size_t available = data_.size() - static_cast<size_t>(offset);
+    const size_t take = n < available ? n : available;
+    std::memcpy(scratch, data_.data() + offset, take);
+    *result = Slice(scratch, take);
+    return Status::OK();
+  }
+ private:
+  std::string data_;
+};
+
+Status ReadPayload(const std::string& payload, CompressionType type,
+                   BlockContents* out) {
+  std::string block = payload;
+  const size_t n = block.size();
+  block.push_back(static_cast<char>(type));
+  block.append(4, '\0');
+  StringSource1349 source(block);
+  BlockHandle handle;
+  handle.set_offset(0);
+  handle.set_size(n);
+  ReadOptions options;
+  options.verify_checksums = false;
+  return ReadBlock(&source, options, handle, out);
+}
+
+TEST(ReadBlockIssue1349Test, RejectsHugeMalformedSnappyBeforeAllocation) {
+#if HAVE_SNAPPY
+  std::string payload;
+  for (unsigned char c : {0xfe, 0xff, 0xff, 0xff, 0x0f})
+    payload.push_back(static_cast<char>(c));
+  BlockContents out;
+  Status s = ReadPayload(payload, kSnappyCompression, &out);
+  EXPECT_TRUE(s.IsCorruption()) << s.ToString();
+#else
+  GTEST_SKIP() << "Snappy support unavailable";
+#endif
+}
+
+TEST(ReadBlockIssue1349Test, RejectsHugeMalformedZstdBeforeAllocation) {
+#if HAVE_ZSTD
+  const unsigned char raw[] = {0x28,0xb5,0x2f,0xfd,0xa0,0xfe,
+                               0xff,0xff,0xff,0x01,0x00,0x00};
+  std::string payload(reinterpret_cast<const char*>(raw), sizeof(raw));
+  BlockContents out;
+  Status s = ReadPayload(payload, kZstdCompression, &out);
+  EXPECT_TRUE(s.IsCorruption()) << s.ToString();
+#else
+  GTEST_SKIP() << "Zstd support unavailable";
+#endif
+}
+
+TEST(ReadBlockIssue1349Test, PreservesValidSnappyFastPath) {
+#if HAVE_SNAPPY
+  std::string input(256 * 1024, 'S'), payload;
+  ASSERT_TRUE(port::Snappy_Compress(input.data(), input.size(), &payload));
+  BlockContents out;
+  Status s = ReadPayload(payload, kSnappyCompression, &out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  EXPECT_EQ(input, out.data.ToString());
+  if (out.heap_allocated) delete[] out.data.data();
+#else
+  GTEST_SKIP() << "Snappy support unavailable";
+#endif
+}
+
+TEST(ReadBlockIssue1349Test, PreservesValidZstdFastPath) {
+#if HAVE_ZSTD
+  std::string input(256 * 1024, 'Z'), payload;
+  ASSERT_TRUE(port::Zstd_Compress(1, input.data(), input.size(), &payload));
+  BlockContents out;
+  Status s = ReadPayload(payload, kZstdCompression, &out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  EXPECT_EQ(input, out.data.ToString());
+  if (out.heap_allocated) delete[] out.data.data();
+#else
+  GTEST_SKIP() << "Zstd support unavailable";
+#endif
+}
+
+TEST(ReadBlockIssue1349Test, PreservesValidSnappyFallback) {
+#if HAVE_SNAPPY
+  std::string input(9 * 1024 * 1024, 'L'), payload;
+  ASSERT_TRUE(port::Snappy_Compress(input.data(), input.size(), &payload));
+  BlockContents out;
+  Status s = ReadPayload(payload, kSnappyCompression, &out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  EXPECT_EQ(input.size(), out.data.size());
+  EXPECT_EQ(0, std::memcmp(input.data(), out.data.data(), input.size()));
+  if (out.heap_allocated) delete[] out.data.data();
+#else
+  GTEST_SKIP() << "Snappy support unavailable";
+#endif
+}
+
+TEST(ReadBlockIssue1349Test, PreservesValidZstdFallback) {
+#if HAVE_ZSTD
+  std::string input(9 * 1024 * 1024, 'Q'), payload;
+  ASSERT_TRUE(port::Zstd_Compress(1, input.data(), input.size(), &payload));
+  BlockContents out;
+  Status s = ReadPayload(payload, kZstdCompression, &out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  EXPECT_EQ(input.size(), out.data.size());
+  EXPECT_EQ(0, std::memcmp(input.data(), out.data.data(), input.size()));
+  if (out.heap_allocated) delete[] out.data.data();
+#else
+  GTEST_SKIP() << "Zstd support unavailable";
+#endif
+}
+
+}  // namespace
+}  // namespace leveldb


### PR DESCRIPTION
## Summary

`ReadBlock` currently obtains the advertised Snappy/Zstd uncompressed length before allocating the output buffer. For malformed blocks, that can cause a very large allocation before the compressed payload has been validated.

This change keeps the existing one-pass path for ordinary blocks and adds a validate-before-large-allocation path:

- compressed outputs up to 8 MiB continue to use the existing fast path
- larger Snappy/Zstd declarations are validated before an equally large allocation is attempted
- the 8 MiB threshold is only a path selector; it is not a maximum accepted block size
- allocation uses `std::nothrow` and returns `Corruption` if the allocation cannot be satisfied
- Zstd frame-size handling rejects error/unknown sentinels and sizes that cannot fit in `size_t`

## Tests

Added `ReadBlockIssue1349Test` coverage for:

- malformed Snappy data advertising a huge output size
- malformed Zstd data advertising a huge output size
- valid Snappy and Zstd blocks on the normal fast path
- valid 9 MiB Snappy and Zstd blocks on the validation path

Local results:

- issue-specific tests: 6/6 passed
- full LevelDB test suite: 217/217 passed
- valid 65 MiB Zstd block remained readable
- benchmark median candidate/baseline ratios: Snappy 0.996x, Zstd 1.000x

This does not impose a global maximum on valid decompressed block sizes; a genuinely valid very large stream may still require a large allocation. The change is scoped to avoiding the pre-validation oversized allocation behavior described in the issue.

Fixes #1349