### PR TITLE
Fix DumpFile path handling on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ if(LEVELDB_BUILD_TESTS)
         "db/corruption_test.cc"
         "db/db_test.cc"
         "db/dbformat_test.cc"
+        "db/dumpfile_test.cc"
         "db/filename_test.cc"
         "db/log_test.cc"
         "db/recovery_test.cc"

--- a/db/dumpfile.cc
+++ b/db/dumpfile.cc
@@ -24,7 +24,7 @@ namespace leveldb {
 namespace {
 
 bool GuessType(const std::string& fname, FileType* type) {
-  size_t pos = fname.rfind('/');
+  size_t pos = fname.find_last_of("/\\");
   std::string basename;
   if (pos == std::string::npos) {
     basename = fname;

--- a/db/dumpfile_test.cc
+++ b/db/dumpfile_test.cc
@@ -35,5 +35,5 @@ TEST(DumpFileTest, AcceptsWindowsPathSeparators) {
 #endif
 }
 
-}
+}  // namespace
 }  // namespace leveldb

--- a/db/dumpfile_test.cc
+++ b/db/dumpfile_test.cc
@@ -35,5 +35,5 @@ TEST(DumpFileTest, AcceptsWindowsPathSeparators) {
 #endif
 }
 
-}  // namespace
+}
 }  // namespace leveldb

--- a/db/dumpfile_test.cc
+++ b/db/dumpfile_test.cc
@@ -17,6 +17,19 @@ class NoopWritableFile : public WritableFile {
   Status Sync() override { return Status::OK(); }
 };
 
+TEST(DumpFileTest, AcceptsUnixPathSeparators) {
+  Env* env = Env::Default();
+  const std::string filename = testing::TempDir() + "000001.log";
+  WritableFile* file;
+  ASSERT_TRUE(env->NewWritableFile(filename, &file).ok());
+  delete file;
+
+  NoopWritableFile sink;
+  ASSERT_TRUE(DumpFile(env, filename, &sink).ok());
+
+  ASSERT_TRUE(env->RemoveFile(filename).ok());
+}
+
 TEST(DumpFileTest, AcceptsWindowsPathSeparators) {
 #if defined(LEVELDB_PLATFORM_WINDOWS)
   Env* env = Env::Default();

--- a/db/dumpfile_test.cc
+++ b/db/dumpfile_test.cc
@@ -1,0 +1,39 @@
+#include "leveldb/dumpfile.h"
+
+#include <algorithm>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "leveldb/env.h"
+
+namespace leveldb {
+namespace {
+
+class NoopWritableFile : public WritableFile {
+ public:
+  Status Append(const Slice&) override { return Status::OK(); }
+  Status Close() override { return Status::OK(); }
+  Status Flush() override { return Status::OK(); }
+  Status Sync() override { return Status::OK(); }
+};
+
+TEST(DumpFileTest, AcceptsWindowsPathSeparators) {
+#if defined(LEVELDB_PLATFORM_WINDOWS)
+  Env* env = Env::Default();
+  const std::string filename = testing::TempDir() + "000001.log";
+  WritableFile* file;
+  ASSERT_TRUE(env->NewWritableFile(filename, &file).ok());
+  delete file;
+
+  std::string windows_filename = filename;
+  std::replace(windows_filename.begin(), windows_filename.end(), '/', '\\');
+
+  NoopWritableFile sink;
+  ASSERT_TRUE(DumpFile(env, windows_filename, &sink).ok());
+
+  ASSERT_TRUE(env->RemoveFile(filename).ok());
+#endif
+}
+
+}
+}  // namespace leveldb


### PR DESCRIPTION
## Summary

Fix `DumpFile` path detection for Windows-style paths. 

`GuessType` only searched for `/` when extracting the filename. As a result, paths such as `C:\path\000001.log` were passed to `ParseFileName` with the directory portion still attached, causing `DumpFile` to reject valid log, table, or manifest files.

Use both `/` and `\` as path separators and add a Unix and Windows regression test.

## Changes

- Update `GuessType` to recognize both Unix and Windows path separators.
- Add a regression test.
- Register the regression test with the existing CMake test target.

## Testing

- Add a Unix-style path test.
- Add a Windows-style path test.
